### PR TITLE
Fixed Task Attachments

### DIFF
--- a/src/app/tasks/[slug]/attachments/[...path]/route.ts
+++ b/src/app/tasks/[slug]/attachments/[...path]/route.ts
@@ -5,14 +5,13 @@ import { NextContext } from "types/nextjs";
 import { normalizeAttachmentPath } from "common/utils/attachments";
 
 type RouteParams = {
-  id: string;
+  slug: string;
   path: string[];
 };
 
 export async function GET(_request: NextRequest, context: NextContext<RouteParams>) {
-  // **Note that this is task SLUG and not task id (NextJS problems)**
   // Parse the task slug and attachment path from the URL
-  const slug = context.params.id;
+  const slug = context.params.slug;
   const path = normalizeAttachmentPath(context.params.path.join("/"));
 
   // Look up in the database which attachment it should be

--- a/src/client/components/task_editor/task_editor_details.tsx
+++ b/src/client/components/task_editor/task_editor_details.tsx
@@ -23,7 +23,7 @@ import {
   useTaskStringPropUpdater,
 } from "./task_editor_utils";
 import { Arrays } from "common/utils/arrays";
-import { APIPath, getAPIPath } from "client/paths";
+import { getPath, Path } from "client/paths";
 import { normalizeAttachmentPath } from "common/utils/attachments";
 
 type TaskEditorDetailsProps = {
@@ -176,7 +176,7 @@ const TaskAttachmentSavedX = ({ index, attachment, task, setTask }: TaskAttachme
       <TaskEditorTableCell deleted={attachment.deleted}>{filename}</TaskEditorTableCell>
       <TaskEditorTableCell deleted={attachment.deleted}>{attachment.path}</TaskEditorTableCell>
       <div className="flex flex-row justify-end items-center px-3 gap-2">
-        <a href={getAttachmentURL(task, attachment)}>
+        <a target="_blank" href={getAttachmentURL(task, attachment)}>
           <BoxIcon name="bx-download" className="bx-sm text-blue-300 hover:text-blue-500" />
         </a>
         <button type="button" onClick={onClickDelete}>
@@ -427,5 +427,5 @@ const TaskEditorCreditLocalX = ({ index, credit, task, setTask }: TaskEditorCred
 };
 
 function getAttachmentURL(task: TaskED, attachment: TaskAttachmentSaved) {
-  return getAPIPath({ kind: APIPath.AttachmentFile, taskId: task.id, path: attachment.path});
+  return getPath({ kind: Path.TaskAttachment, slug: task.slug, path: attachment.path});
 }

--- a/src/client/components/task_editor/task_editor_details.tsx
+++ b/src/client/components/task_editor/task_editor_details.tsx
@@ -24,6 +24,7 @@ import {
 } from "./task_editor_utils";
 import { Arrays } from "common/utils/arrays";
 import { APIPath, getAPIPath } from "client/paths";
+import { normalizeAttachmentPath } from "common/utils/attachments";
 
 type TaskEditorDetailsProps = {
   task: TaskED;
@@ -82,7 +83,7 @@ const TaskEditorAttachments = ({ task, setTask }: TaskEditorAttachmentsProps) =>
         file: newFile,
         path: file.name,
         filename: file.name,
-        mime_type: "",
+        mime_type: file.type,
         deleted: false,
       };
 
@@ -207,6 +208,19 @@ const TaskAttachmentLocalX = ({ index, attachment, task, setTask }: TaskAttachme
     [task, attachment, index]
   );
 
+  const onBlurPath = useCallback(
+    (event: InputChangeEvent) => {
+      setTask({
+        ...task,
+        attachments: Arrays.replaceNth(task.attachments, index, {
+          ...attachment,
+          path: normalizeAttachmentPath(attachment.path),
+        }),
+      });
+    },
+    [task, attachment, index]
+  );
+
   const onClickDelete = useCallback(() => {
     setTask({
       ...task,
@@ -218,7 +232,7 @@ const TaskAttachmentLocalX = ({ index, attachment, task, setTask }: TaskAttachme
     <>
       <TaskEditorTableCell deleted={false}>{attachment.filename}</TaskEditorTableCell>
       <TaskEditorTableCell deleted={false}>
-        <input type="text" value={attachment.path} onChange={onChangePath} className="w-full" />
+        <input type="text" value={attachment.path} onBlur={onBlurPath} onChange={onChangePath} className="w-full" />
       </TaskEditorTableCell>
       <div className="flex flex-row justify-end items-center px-3 gap-2">
         <button type="button" onClick={onClickDelete}>

--- a/src/client/paths.ts
+++ b/src/client/paths.ts
@@ -6,13 +6,15 @@ export enum Path {
   Submission = "Submission",
   TaskView = "TaskView",
   TaskEdit = "TaskEdit",
+  TaskAttachment = "TaskAttachment",
 }
 
 export type PathArguments =
   | { kind: Path.Home }
   | { kind: Path.Submission; uuid: string }
   | { kind: Path.TaskView; slug: string }
-  | { kind: Path.TaskEdit; uuid: string };
+  | { kind: Path.TaskEdit; uuid: string }
+  | { kind: Path.TaskAttachment; slug: string; path: string };
 
 export function getPath(args: PathArguments) {
   switch (args.kind) {
@@ -24,6 +26,8 @@ export function getPath(args: PathArguments) {
       return `/tasks/${args.slug}`;
     case Path.TaskEdit:
       return `/tasks/${uuidToHuradoID(args.uuid)}/edit`;
+    case Path.TaskAttachment:
+      return `/tasks/${args.slug}/attachments/${args.path}`;
     default:
       throw new UnreachableError(args);
   }
@@ -43,7 +47,6 @@ export enum APIPath {
 
 export type APIPathArguments =
   | { kind: APIPath.Login }
-  | { kind: APIPath.AttachmentFile; taskId: string; path: string }
   | { kind: APIPath.SubmissionCreate }
   | { kind: APIPath.UserSubmissions; taskId?: string }
   | { kind: APIPath.FileHashes }
@@ -56,8 +59,6 @@ export function getAPIPath(args: APIPathArguments) {
   switch (args.kind) {
     case APIPath.Login:
       return "/api/v1/auth/login";
-    case APIPath.AttachmentFile:
-      return `/api/v1/tasks/${args.taskId}/attachments/${args.path}`;
     case APIPath.SubmissionCreate:
       return "/api/v1/submissions";
     case APIPath.UserSubmissions:

--- a/src/common/utils/attachments.ts
+++ b/src/common/utils/attachments.ts
@@ -1,0 +1,22 @@
+export function normalizeAttachmentPath(filePath: string): string {
+  const normalized = unixNormalizePath(filePath);
+  const noslashes = normalized.replace(/^\/+/, "").replace(/\/+$/, "");
+  return noslashes;
+}
+
+function unixNormalizePath(path: string) {
+  const parts = path.split("/").filter((part) => part !== "" && part !== ".");
+  const stack: string[] = [];
+
+  for (const part of parts) {
+    if (part === "..") {
+      if (stack.length > 0) {
+        stack.pop();
+      }
+    } else {
+      stack.push(part);
+    }
+  }
+
+  return stack.join("/");
+}

--- a/src/server/logic/tasks/update_editor_task.ts
+++ b/src/server/logic/tasks/update_editor_task.ts
@@ -1,4 +1,3 @@
-import path from "path";
 import { Selectable, Transaction } from "kysely";
 import { db } from "db";
 import {

--- a/src/server/logic/tasks/update_editor_task.ts
+++ b/src/server/logic/tasks/update_editor_task.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { Selectable, Transaction } from "kysely";
 import { db } from "db";
 import {
@@ -14,6 +15,7 @@ import {
   TaskDTO,
   TaskSubtaskDTO,
 } from "common/validation/task_validation";
+import { normalizeAttachmentPath } from "common/utils/attachments";
 
 type Ordered<T> = T & {
   order: number;
@@ -116,7 +118,7 @@ async function upsertTaskAttachments(
           .insertInto("task_attachments")
           .values(
             attachmentsNew.map((attach) => ({
-              path: attach.path,
+              path: normalizeAttachmentPath(attach.path),
               mime_type: attach.mime_type,
               file_hash: attach.file_hash,
               task_id: taskId,
@@ -267,7 +269,7 @@ async function upsertTaskData(
   const dataNew = dataAll.filter((d) => d.id == null);
   const dataOld = dataAll.filter((d) => d.id != null);
 
-  const subtaskIds = subtasks.map(subtask => subtask.id);
+  const subtaskIds = subtasks.map((subtask) => subtask.id);
   if (subtaskIds.length > 0) {
     const dataOldIds = dataOld.map((data) => data.id as string);
     if (dataOldIds.length <= 0) {


### PR DESCRIPTION
* Attachments are accessed from a more intuitive URL (`/tasks/:slug/attachments/...path`)
* Fixed the database query so that it actually works now
* Fixed mime type being set to `""` instead of the user's browser's guess