### PR TITLE
Use criyle/go-judge as the runner

### DIFF
--- a/Dockerfile.go-judge
+++ b/Dockerfile.go-judge
@@ -1,0 +1,39 @@
+# Based on https://github.com/criyle/go-judge-demo/blob/master/Dockerfile.exec
+
+FROM criyle/go-judge:v1.8.5 AS go-judge
+
+FROM debian:bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    python3 \
+    pypy3 \
+    fpc \
+    openjdk-17-jdk \
+    nodejs \
+    golang-go \
+    php-cli \
+    ghc \
+    rustc \
+    ruby \
+    node-typescript \
+    mono-mcs \
+    rakudo \
+    perl \
+    ocaml \
+    vim \
+    nano \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* 
+
+WORKDIR /opt
+
+COPY --from=go-judge /opt/go-judge /opt/mount.yaml /opt/
+
+EXPOSE 5050/tcp 5051/tcp
+
+ENTRYPOINT ["./go-judge"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,10 @@ services:
     restart: always
     depends_on:
       - hurado-postgres
+      - hurado-go-judge
     links:
       - hurado-postgres
+      - hurado-go-judge
     volumes:
       - ./:/app/
   hurado-judge:
@@ -64,3 +66,11 @@ services:
       - "6379"  # Blob service
     volumes:
       - ./volumes/redis:/data
+  hurado-go-judge:
+    container_name: hurado-go-judge
+    build:
+      dockerfile: Dockerfile.go-judge
+    ports:
+      - 5050:5050 # REST API
+      - 5051:5051 # gRPC
+    privileged: true # more efficient

--- a/src/client/components/submit_panel/submit_panel.tsx
+++ b/src/client/components/submit_panel/submit_panel.tsx
@@ -72,6 +72,8 @@ export const SubmitPanel = ({ taskId }: SubmitPanelProps) => {
       <div className="flex py-2 pl-4 pr-6 border-b border-gray-300">
         <select className={styles.language} value={language} onChange={onChangeLanguage}>
           <option value={Language.Python3}>{humanizeLanguage(Language.Python3)}</option>
+          <option value={Language.CPP}>{humanizeLanguage(Language.CPP)}</option>
+          <option value={Language.Java}>{humanizeLanguage(Language.Java)}</option>
         </select>
       </div>
       <div className={classNames(styles.editor, "border-b border-gray-300")}>

--- a/src/server/evaluation/go-judge.ts
+++ b/src/server/evaluation/go-judge.ts
@@ -1,0 +1,175 @@
+import { Language, Verdict } from "common/types/constants";
+import type { JudgeSubmission, JudgeTask, JudgeTaskData } from "common/types/judge";
+import fs from "fs";
+import path from "path";
+import { CompilationResult, EvaluationResult, getLanguageFilename } from ".";
+
+// See https://github.com/criyle/go-judge/tree/master?tab=readme-ov-file#rest-api-interface
+const baseURL = "http://hurado-go-judge:5050";
+
+const evalSpecs = {
+  [Language.Python3]: {
+    sourceFileName: "main.py",
+    compileCmd: [
+      "/usr/bin/python3",
+      "-c",
+      "import py_compile; py_compile.compile('main.py', 'main.pyc', doraise=True)",
+    ],
+    execFileNames: ["main.py", "main.pyc"],
+    runCmd: ["/usr/bin/python3", "main.py"],
+  },
+  [Language.CPP]: {
+    sourceFileName: "main.cpp",
+    compileCmd: ["/usr/bin/g++", "-O2", "-std=c++11", "-o", "main", "main.cpp"],
+    execFileNames: ["main"],
+    runCmd: ["main"],
+  },
+  [Language.Java]: {
+    sourceFileName: "Main.java",
+    compileCmd: ["/usr/bin/javac", "Main.java"],
+    execFileNames: ["Main.class"],
+    runCmd: ["/usr/bin/java", "Main"],
+  },
+};
+
+export type GoJudgeEvaluationContext = {
+  judgeRoot: string;
+  language: Language;
+  execFileIds: Record<string, string>;
+};
+
+export async function compileSubmission(
+  task: JudgeTask,
+  submission: JudgeSubmission,
+  taskDir: string,
+  submissionDir: string
+): Promise<CompilationResult<GoJudgeEvaluationContext>> {
+  const lang = submission.language as Language;
+  const spec = evalSpecs[lang];
+  const sourcePath = path.join(submissionDir, getLanguageFilename(lang));
+  const reqBody = {
+    "cmd": [
+      {
+        "args": spec.compileCmd,
+        "env": ["PATH=/usr/bin:/bin"],
+        "files": [
+          {
+            "content": "",
+          },
+          {
+            "name": "stdout",
+            "max": 10240,
+          },
+          {
+            "name": "stderr",
+            "max": 10240,
+          },
+        ],
+        "cpuLimit": 10000000000,
+        "memoryLimit": 104857600,
+        "procLimit": 50,
+        "copyIn": {
+          [spec.sourceFileName]: {
+            "content": fs.readFileSync(sourcePath, "utf8"),
+          },
+        },
+        "copyOut": ["stdout", "stderr"],
+        "copyOutCached": spec.execFileNames,
+      },
+    ],
+  };
+  const res = await fetch(`${baseURL}/run`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(reqBody),
+  });
+  if (res.status != 200) {
+    // TODO: Handle system error
+    throw new Error(`Unexpected response while compiling: ${JSON.stringify(await res.blob())}`);
+  }
+  const resBody = (await res.json())[0];
+  if (resBody.status !== "Accepted") {
+    // TODO: Handle compilation error
+    throw new Error(`Unexpected response while compiling: ${JSON.stringify(resBody)}`);
+  }
+  return {
+    compile_time_ms: Math.round(resBody.time / 1000000),
+    compile_memory_byte: resBody.memory,
+    context: {
+      judgeRoot: taskDir,
+      language: lang,
+      execFileIds: resBody.fileIds,
+    },
+  };
+}
+
+export async function evaluateTaskData(
+  context: GoJudgeEvaluationContext,
+  data: JudgeTaskData
+): Promise<EvaluationResult> {
+  const spec = evalSpecs[context.language];
+  const inputPath = path.join(context.judgeRoot, data.input_file_name);
+  const outputPath = path.join(context.judgeRoot, data.output_file_name);
+  const reqBody = {
+    "cmd": [
+      {
+        "args": spec.runCmd,
+        "env": ["PATH=/usr/bin:/bin"],
+        "files": [
+          {
+            "content": fs.readFileSync(inputPath, "utf8"),
+          },
+          {
+            "name": "stdout",
+            "max": 10240,
+          },
+          {
+            "name": "stderr",
+            "max": 10240,
+          },
+        ],
+        "cpuLimit": 10000000000,
+        "memoryLimit": 104857600,
+        "procLimit": 50,
+        "copyIn": Object.fromEntries(
+          Object.entries(context.execFileIds).map(([k, v]) => [k, { "fileId": v }])
+        ),
+        "copyOut": ["stdout", "stderr"],
+        "copyOutCached": [],
+      },
+    ],
+  };
+  const res = await fetch(`${baseURL}/run`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(reqBody),
+  });
+  if (res.status != 200) {
+    // TODO: Handle system error
+    throw new Error(`Unexpected response while running: ${JSON.stringify(await res.blob())}`);
+  }
+  const resBody = (await res.json())[0];
+  let verdict: Verdict =
+    {
+      "Accepted": Verdict.Accepted, // provisional, not yet compared to answer
+      "Memory Limit Exceeded": Verdict.MemoryLimitExceeded,
+      "Time Limit Exceeded": Verdict.TimeLimitExceeded,
+      "Internal Error": Verdict.RuntimeError, // TODO: Add a new verdict to handle this?
+    }[resBody.status as string] ?? Verdict.RuntimeError;
+  let score = 0;
+  if (verdict === Verdict.Accepted) {
+    // Just verbatim comparison for now.
+    const answer = fs.readFileSync(outputPath, "utf8");
+    if (answer === resBody.files.stdout) {
+      score = 1;
+    } else {
+      verdict = Verdict.WrongAnswer;
+    }
+  }
+  return {
+    verdict,
+    raw_score: score,
+    running_time_ms: Math.round(resBody.time / 1000000),
+    running_memory_byte: resBody.memory,
+  };
+}

--- a/src/server/evaluation/index.ts
+++ b/src/server/evaluation/index.ts
@@ -1,8 +1,8 @@
 import ChildProcess from "child_process";
-import fs from "fs";
-import path from "path";
 import { Language, Verdict } from "common/types/constants";
 import { JudgeSubmission, JudgeTask, JudgeTaskData } from "common/types/judge";
+import fs from "fs";
+import path from "path";
 
 // Pass in anything you need to do the judgments
 export type EvaluationContext = {
@@ -18,8 +18,8 @@ export type EvaluationResult = {
   running_memory_byte: number;
 };
 
-export type CompilationResult = {
-  context: EvaluationContext;
+export type CompilationResult<Context> = {
+  context: Context;
   compile_time_ms: number;
   compile_memory_byte: number;
 };
@@ -29,7 +29,7 @@ export async function compileSubmission(
   submission: JudgeSubmission,
   taskDir: string,
   submissionDir: string
-): Promise<CompilationResult> {
+): Promise<CompilationResult<EvaluationContext>> {
   const mainFilename = getLanguageFilename(submission.language as Language);
 
   const context: EvaluationContext = {

--- a/src/server/logic/judgements/judge_runner.ts
+++ b/src/server/logic/judgements/judge_runner.ts
@@ -1,4 +1,3 @@
-import path from "path";
 import { Language, Verdict } from "common/types/constants";
 import {
   JudgeSubmission,
@@ -10,12 +9,12 @@ import {
   JudgeVerdictTaskData,
 } from "common/types/judge";
 import { db } from "db";
+import { CompilationResult, EvaluationContext } from "server/evaluation";
 import {
-  CompilationResult,
   compileSubmission,
   evaluateTaskData,
-  EvaluationContext,
-} from "server/evaluation";
+  GoJudgeEvaluationContext,
+} from "server/evaluation/go-judge";
 
 export class JudgeRunner {
   static async evaluate(
@@ -31,7 +30,7 @@ export class JudgeRunner {
 }
 
 async function runTask(
-  compilation: CompilationResult,
+  compilation: CompilationResult<GoJudgeEvaluationContext>,
   task: JudgeTask,
   submission: JudgeSubmission
 ): Promise<JudgeVerdict> {
@@ -103,7 +102,7 @@ async function runTask(
 }
 
 async function runSubtask(
-  context: EvaluationContext,
+  context: GoJudgeEvaluationContext,
   verdict_id: string,
   subtask: JudgeSubtask
 ): Promise<JudgeVerdictSubtask> {
@@ -160,7 +159,7 @@ async function runSubtask(
 }
 
 async function runTestData(
-  context: EvaluationContext,
+  context: GoJudgeEvaluationContext,
   verdict_subtask_id: string,
   task_data: JudgeTaskData
 ): Promise<JudgeVerdictTaskData> {

--- a/src/server/logic/submissions/judge_submission.ts
+++ b/src/server/logic/submissions/judge_submission.ts
@@ -1,5 +1,5 @@
 import { db } from "db";
-import { JudgeVerdict, JudgeSubmission, JudgeSubtask, JudgeTask } from "server/logic/judgements/judge_types";
+import type { JudgeVerdict, JudgeSubmission, JudgeSubtask, JudgeTask } from "common/types/judge";
 import { JudgeFiles } from "server/logic/judgements/judge_files";
 import { JudgeRunner } from "server/logic/judgements/judge_runner";
 


### PR DESCRIPTION
The actual sandboxed runner is [criyle/go-sandbox](https://github.com/criyle/go-sandbox). [go-judge](https://github.com/criyle/go-judge) wraps it to expose a nifty API via REST or gRPC that I think can handle everything we need (it supports the interactive use case, too).
    
Code is not yet polished and lots cases (like compilation error) aren't handled yet.
