### PR TITLE
kompgen endpoint

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,3 +9,4 @@ DOCKER_POSTGRES_HOSTNAME=hurado-postgres
 REDIS_HOST=hurado-redis
 REDIS_PORT=6379
 AZURE_STORAGE_CONNECTION_STRING='DefaultEndpointsProtocol=http;AccountName=hurado;AccountKey=password";BlobEndpoint=http://hurado-azurite:10000/hurado;'
+KOMPGEN_SECRET='kevinsogosogokevin'

--- a/src/app/api/v1/tasks/[id]/kg/route.ts
+++ b/src/app/api/v1/tasks/[id]/kg/route.ts
@@ -5,7 +5,6 @@ import { db } from "db";
 import { NextRequest, NextResponse } from "next/server";
 import { canManageTasks } from "server/authorization";
 import { upsertTaskData, upsertTaskSubtasks } from "server/logic/tasks/update_editor_task";
-import { KOMPGEN_SECRET } from "server/secrets";
 import { getSession } from "server/sessions";
 import { z } from "zod";
 

--- a/src/app/api/v1/tasks/[id]/kg/route.ts
+++ b/src/app/api/v1/tasks/[id]/kg/route.ts
@@ -1,0 +1,100 @@
+import { TaskType } from "common/types/constants";
+import { REGEX_SLUG } from "common/validation/common_validation";
+import { zTaskSubtaskBatch, zTaskSubtaskCommunication, zTaskSubtaskOutput } from "common/validation/task_validation";
+import { db } from "db";
+import { NextRequest, NextResponse } from "next/server";
+import { canManageTasks } from "server/authorization";
+import { upsertTaskData, upsertTaskSubtasks } from "server/logic/tasks/update_editor_task";
+import { KOMPGEN_SECRET } from "server/secrets";
+import { getSession } from "server/sessions";
+import { z } from "zod";
+
+// Updates only a subset of the properties that kg knows about, and
+//   DOESN'T OVERWRITE THE OTHER PROPERTIES!!!
+export async function PUT(request: NextRequest) {
+  const session = getSession(request);
+  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
+    return NextResponse.json({}, { status: 403 });
+  }
+
+  const data = await request.json();
+  const parsed = zKgUpdateTaskSchema.safeParse(data);
+  if (parsed.success) {
+    const task = await updateKgTask(parsed.data);
+    return NextResponse.json(task);
+  } else {
+    return NextResponse.json({ error: parsed.error.format() }, { status: 400 });
+  }
+}
+
+const zKgUpdateTaskCommon = {
+  id: z.string().uuid(),
+  slug: z.string().min(1).regex(REGEX_SLUG),
+  title: z.string().min(1),
+  is_public: z.boolean(),
+  score_max: z.number().nonnegative(),
+};
+
+const zKgUpdateTaskTypeBatch = z.object({
+  ...zKgUpdateTaskCommon,
+  type: z.literal(TaskType.Batch),
+  time_limit_ms: z.number().nonnegative().nullable(),
+  subtasks: z.array(zTaskSubtaskBatch),
+});
+
+const zKgUpdateTaskTypeCommunication = z.object({
+  ...zKgUpdateTaskCommon,
+  type: z.literal(TaskType.Communication),
+  time_limit_ms: z.number().nonnegative().nullable(),
+  subtasks: z.array(zTaskSubtaskCommunication),
+});
+
+const zKgUpdateTaskTypeOutput = z.object({
+  ...zKgUpdateTaskCommon,
+  type: z.literal(TaskType.OutputOnly),
+  subtasks: z.array(zTaskSubtaskOutput),
+});
+
+const zKgUpdateTaskSchema = z
+  .discriminatedUnion("type", [zKgUpdateTaskTypeBatch, zKgUpdateTaskTypeOutput, zKgUpdateTaskTypeCommunication]);
+
+type KgTaskDTO = z.infer<typeof zKgUpdateTaskTypeBatch> | z.infer<typeof zKgUpdateTaskTypeCommunication> | z.infer<typeof zKgUpdateTaskTypeOutput>;
+
+async function updateKgTask(task: KgTaskDTO) {
+  return db.transaction().execute(async (trx) => {
+    const dbTask = await trx
+      .updateTable("tasks")
+      .set({
+        id: task.id,
+        type: task.type,
+        slug: task.slug,
+        title: task.title,
+        score_max: task.score_max,
+        time_limit_ms: "time_limit_ms" in task ? task.time_limit_ms : null,
+      })
+      .where("id", "=", task.id)
+      .returning([
+        "id",
+        "type",
+        "slug",
+        "title",
+        "is_public",
+        "score_max",
+        "time_limit_ms",
+      ])
+      .executeTakeFirstOrThrow();
+
+    const { subtasks: dbSubtasks, subtasksWithData } = await upsertTaskSubtasks(
+      trx,
+      task.id,
+      task.subtasks
+    );
+    const dbTaskData = await upsertTaskData(trx, subtasksWithData);
+
+    return {
+      id: dbTask.id,
+      slug: dbTask.slug,
+      title: dbTask.title,
+    }
+  });
+}

--- a/src/app/api/v1/tasks/[id]/kg/route.ts
+++ b/src/app/api/v1/tasks/[id]/kg/route.ts
@@ -89,7 +89,7 @@ async function updateKgTask(task: KgTaskDTO) {
       task.id,
       task.subtasks
     );
-    const dbTaskData = await upsertTaskData(trx, subtasksWithData);
+    // const dbTaskData = await upsertTaskData(trx, subtasksWithData);
 
     return {
       id: dbTask.id,

--- a/src/app/api/v1/tasks/[id]/kg/route.ts
+++ b/src/app/api/v1/tasks/[id]/kg/route.ts
@@ -89,7 +89,7 @@ async function updateKgTask(task: KgTaskDTO) {
       task.id,
       task.subtasks
     );
-    // const dbTaskData = await upsertTaskData(trx, subtasksWithData);
+    const dbTaskData = await upsertTaskData(trx, subtasksWithData);
 
     return {
       id: dbTask.id,

--- a/src/app/api/v1/tasks/[id]/kg/route.ts
+++ b/src/app/api/v1/tasks/[id]/kg/route.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 //   DOESN'T OVERWRITE THE OTHER PROPERTIES!!!
 export async function PUT(request: NextRequest) {
   const session = getSession(request);
-  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
+  if (!canManageTasks(session, request)) {
     return NextResponse.json({}, { status: 403 });
   }
 

--- a/src/app/api/v1/tasks/[id]/route.ts
+++ b/src/app/api/v1/tasks/[id]/route.ts
@@ -4,9 +4,9 @@ import { canManageTasks } from "server/authorization";
 import { updateEditorTask } from "server/logic/tasks/update_editor_task";
 import { getSession } from "server/sessions";
 import { NextContext } from "types/nextjs";
-import { checkUUIDv4, huradoIDToUUID } from "common/utils/uuid";
-import { db } from "db";
 import { TaskLookupDTO } from "common/types";
+import { KOMPGEN_SECRET } from "server/secrets";
+import { lookupFromSlugOrId } from "./utils";
 
 type RouteParams = {
   id: string;
@@ -14,7 +14,7 @@ type RouteParams = {
 
 export async function PUT(request: NextRequest) {
   const session = getSession(request);
-  if (!canManageTasks(session)) {
+  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
     return NextResponse.json({}, { status: 403 });
   }
 
@@ -30,45 +30,21 @@ export async function PUT(request: NextRequest) {
 
 export async function GET(request: NextRequest, context: NextContext<RouteParams>) {
   const session = getSession(request);
-  if (!canManageTasks(session)) {
-    return NextResponse.json({}, { status: 404 });
+  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
+    return NextResponse.json({}, { status: 403 });
   }
 
   // Accept any of slug, uuid, or hurado id
   const slug = context.params.id;
-  const uuid = huradoIDToUUID(slug) ?? checkUUIDv4(slug);
-
-  const lookups = await db
-    .selectFrom("tasks")
-    .where((eb) => {
-      if (uuid != null) {
-        return eb.or([eb("id", "=", uuid), eb("slug", "=", slug)]);
-      } else {
-        return eb("slug", "=", slug);
-      }
-    })
-    .select(["id", "slug", "title"])
-    .execute();
-
-
-  if (lookups.length == 0) {
+  const first = await lookupFromSlugOrId(slug, ["id", "slug", "title"]);
+  if (first == null) {
     return NextResponse.json(null, { status: 404 });
   }
 
-  // Sort the results. Matching UUID trumps matching slug. Best result goes to lowest index.
-  lookups.sort((a, b) => {
-    if (a.id === uuid) {
-      return b.id === uuid ? 0 : -1;
-    }
-    return b.id === uuid ? 1 : 0;
-  });
-
-  const first = lookups[0];
   const dto: TaskLookupDTO = {
     id: first.id,
     slug: first.slug,
     title: first.title,
   };
-
   return NextResponse.json(dto);
 }

--- a/src/app/api/v1/tasks/[id]/route.ts
+++ b/src/app/api/v1/tasks/[id]/route.ts
@@ -5,7 +5,6 @@ import { updateEditorTask } from "server/logic/tasks/update_editor_task";
 import { getSession } from "server/sessions";
 import { NextContext } from "types/nextjs";
 import { TaskLookupDTO } from "common/types";
-import { KOMPGEN_SECRET } from "server/secrets";
 import { lookupFromSlugOrId } from "./utils";
 
 type RouteParams = {
@@ -36,7 +35,7 @@ export async function GET(request: NextRequest, context: NextContext<RouteParams
 
   // Accept any of slug, uuid, or hurado id
   const slug = context.params.id;
-  const first = await lookupFromSlugOrId(slug, ["id", "slug", "title"]);
+  const first = await lookupFromSlugOrId(slug);
   if (first == null) {
     return NextResponse.json(null, { status: 404 });
   }

--- a/src/app/api/v1/tasks/[id]/route.ts
+++ b/src/app/api/v1/tasks/[id]/route.ts
@@ -14,7 +14,7 @@ type RouteParams = {
 
 export async function PUT(request: NextRequest) {
   const session = getSession(request);
-  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
+  if (!canManageTasks(session, request)) {
     return NextResponse.json({}, { status: 403 });
   }
 
@@ -30,7 +30,7 @@ export async function PUT(request: NextRequest) {
 
 export async function GET(request: NextRequest, context: NextContext<RouteParams>) {
   const session = getSession(request);
-  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
+  if (!canManageTasks(session, request)) {
     return NextResponse.json({}, { status: 403 });
   }
 

--- a/src/app/api/v1/tasks/[id]/submissions/route.ts
+++ b/src/app/api/v1/tasks/[id]/submissions/route.ts
@@ -12,7 +12,7 @@ type RouteParams = {
 
 export async function GET(request: NextRequest, context: NextContext<RouteParams>) {
   const session = getSession(request);
-  if (!canManageTasks(session)) {
+  if (!canManageTasks(session, request)) {
     return NextResponse.json({}, { status: 401 });
   }
 

--- a/src/app/api/v1/tasks/[id]/utils.ts
+++ b/src/app/api/v1/tasks/[id]/utils.ts
@@ -1,8 +1,8 @@
-import { Models } from "common/types";
 import { checkUUIDv4, huradoIDToUUID } from "common/utils/uuid";
 import { db } from "db";
-import { SelectExpression } from "kysely";
-export async function lookupFromSlugOrId(slug: string, columns: ReadonlyArray<SelectExpression<Models, 'tasks'>>) {
+
+
+export async function lookupFromSlugOrId(slug: string) {
   const uuid = huradoIDToUUID(slug) ?? checkUUIDv4(slug);
 
   const lookups = await db
@@ -14,7 +14,7 @@ export async function lookupFromSlugOrId(slug: string, columns: ReadonlyArray<Se
         return eb("slug", "=", slug);
       }
     })
-    .select(columns)
+    .select(["id", "slug", "title"])
     .execute();
 
 

--- a/src/app/api/v1/tasks/[id]/utils.ts
+++ b/src/app/api/v1/tasks/[id]/utils.ts
@@ -1,0 +1,30 @@
+import { Models } from "common/types";
+import { checkUUIDv4, huradoIDToUUID } from "common/utils/uuid";
+import { db } from "db";
+import { SelectExpression } from "kysely";
+export async function lookupFromSlugOrId(slug: string, columns: ReadonlyArray<SelectExpression<Models, 'tasks'>>) {
+  const uuid = huradoIDToUUID(slug) ?? checkUUIDv4(slug);
+
+  const lookups = await db
+    .selectFrom("tasks")
+    .where((eb) => {
+      if (uuid != null) {
+        return eb.or([eb("id", "=", uuid), eb("slug", "=", slug)]);
+      } else {
+        return eb("slug", "=", slug);
+      }
+    })
+    .select(columns)
+    .execute();
+
+
+  // Sort the results. Matching UUID trumps matching slug. Best result goes to lowest index.
+  lookups.sort((a, b) => {
+    if (a.id === uuid) {
+      return b.id === uuid ? 0 : -1;
+    }
+    return b.id === uuid ? 1 : 0;
+  });
+
+  return lookups[0];
+}

--- a/src/app/api/v1/tasks/files/hashes/route.ts
+++ b/src/app/api/v1/tasks/files/hashes/route.ts
@@ -1,7 +1,6 @@
 import { db } from "db";
 import { NextRequest, NextResponse } from "next/server";
 import { canManageTasks } from "server/authorization";
-import { KOMPGEN_SECRET } from "server/secrets";
 import { getSession } from "server/sessions";
 import { z } from "zod";
 

--- a/src/app/api/v1/tasks/files/hashes/route.ts
+++ b/src/app/api/v1/tasks/files/hashes/route.ts
@@ -1,6 +1,7 @@
 import { db } from "db";
 import { NextRequest, NextResponse } from "next/server";
 import { canManageTasks } from "server/authorization";
+import { KOMPGEN_SECRET } from "server/secrets";
 import { getSession } from "server/sessions";
 import { z } from "zod";
 
@@ -10,7 +11,7 @@ export async function POST(request: NextRequest) {
   // This function accepts an array of hashes (string[]) and finds all hashes
   // in that list that are already in the database, so you can skip re-uploading them.
   const session = getSession(request);
-  if (!canManageTasks(session)) {
+  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
     return NextResponse.json({}, { status: 401 });
   }
 

--- a/src/app/api/v1/tasks/files/hashes/route.ts
+++ b/src/app/api/v1/tasks/files/hashes/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: NextRequest) {
   // This function accepts an array of hashes (string[]) and finds all hashes
   // in that list that are already in the database, so you can skip re-uploading them.
   const session = getSession(request);
-  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
+  if (!canManageTasks(session, request)) {
     return NextResponse.json({}, { status: 401 });
   }
 

--- a/src/app/api/v1/tasks/files/route.ts
+++ b/src/app/api/v1/tasks/files/route.ts
@@ -5,7 +5,6 @@ import { db } from "db";
 import { canManageTasks } from "server/authorization";
 import { TaskFileStorage } from "server/files";
 import { getSession } from "server/sessions";
-import { KOMPGEN_SECRET } from "server/secrets";
 
 function isFile(obj: FormDataEntryValue): obj is File {
   return typeof (obj as any)['arrayBuffer'] === 'function';

--- a/src/app/api/v1/tasks/files/route.ts
+++ b/src/app/api/v1/tasks/files/route.ts
@@ -5,18 +5,27 @@ import { db } from "db";
 import { canManageTasks } from "server/authorization";
 import { TaskFileStorage } from "server/files";
 import { getSession } from "server/sessions";
+import { KOMPGEN_SECRET } from "server/secrets";
+
+function isFile(obj: FormDataEntryValue): obj is File {
+  return typeof (obj as any)['arrayBuffer'] === 'function';
+}
 
 export async function POST(request: NextRequest) {
   // This accepts one uploaded file, hashes it, and stores it in blob storage
   // if the file hash already exists, it just returns the hash of the file
   // with status code 409_Conflict
   const session = getSession(request);
-  if (!canManageTasks(session)) {
+  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
     return NextResponse.json({}, { status: 401 });
   }
 
-  const blob = await request.blob();
-  const buffer = await blob.arrayBuffer();
+  const formData = await request.formData();
+  const file = formData.get('file');
+  if (file == null || !isFile(file)) {
+    return NextResponse.json({ error: "File not attached" }, { status: 400 });
+  }
+  const buffer = await file.arrayBuffer();
   const hash = await sha256(buffer);
 
   const current = await db
@@ -38,17 +47,16 @@ export async function POST(request: NextRequest) {
   await blobClient.uploadData(buffer);
 
   try {
-    const file = await db
+    const uploadedFile = await db
       .insertInto("files")
       .values({
         hash: hash,
-        size: blob.size,
+        size: file.size,
       })
       .returning("hash")
       .executeTakeFirstOrThrow();
-
     return NextResponse.json<FileUploadResponse>({
-      hash: file.hash,
+      hash: uploadedFile.hash,
     });
   } catch {
     return NextResponse.json<FileUploadResponse>({

--- a/src/app/api/v1/tasks/files/route.ts
+++ b/src/app/api/v1/tasks/files/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
   // if the file hash already exists, it just returns the hash of the file
   // with status code 409_Conflict
   const session = getSession(request);
-  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
+  if (!canManageTasks(session, request)) {
     return NextResponse.json({}, { status: 401 });
   }
 

--- a/src/app/api/v1/tasks/route.ts
+++ b/src/app/api/v1/tasks/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { zTaskSchema } from "common/validation/task_validation";
-import { KOMPGEN_SECRET } from "server/secrets";
 import { db } from "db";
 import { updateEditorTask } from "server/logic/tasks/update_editor_task";
 import { getSession } from "server/sessions";

--- a/src/app/api/v1/tasks/route.ts
+++ b/src/app/api/v1/tasks/route.ts
@@ -8,7 +8,7 @@ import { canManageTasks } from "server/authorization";
 
 export async function POST(request: NextRequest) {
   const session = getSession(request);
-  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
+  if (!canManageTasks(session, request)) {
     return NextResponse.json({}, { status: 401 });
   }
 

--- a/src/app/api/v1/tasks/route.ts
+++ b/src/app/api/v1/tasks/route.ts
@@ -1,14 +1,42 @@
 import { NextRequest, NextResponse } from "next/server";
-import { canManageTasks } from "server/authorization";
+import { zTaskSchema } from "common/validation/task_validation";
+import { KOMPGEN_SECRET } from "server/secrets";
+import { db } from "db";
+import { updateEditorTask } from "server/logic/tasks/update_editor_task";
 import { getSession } from "server/sessions";
+import { canManageTasks } from "server/authorization";
 
 export async function POST(request: NextRequest) {
   const session = getSession(request);
-  if (!canManageTasks(session)) {
+  if (!canManageTasks(session) && request.headers.get('Authorization') !== KOMPGEN_SECRET) {
     return NextResponse.json({}, { status: 401 });
   }
 
   const data = await request.json();
-  console.log(data);
-  return NextResponse.json({ message: "this is supposed to make a new task" });
+  const parsed = zTaskSchema.safeParse(data);
+  if (parsed.success) {
+    const task = parsed.data;
+    const dbTasks = await db
+      .insertInto("tasks")
+      .values([
+        {
+          title: task.title,
+          slug: task.slug,
+          statement: task.statement,
+          is_public: task.is_public,
+          type: task.type,
+          score_max: task.score_max,
+          checker_kind: task.checker_kind,
+        },
+      ])
+      .returning(["id"])
+      .execute();
+
+    task.id = dbTasks[0].id; // overwrite the dummy value
+    await updateEditorTask(task);
+    return NextResponse.json(task);
+
+  } else {
+    return NextResponse.json({ error: parsed.error.format() }, { status: 400 });
+  }
 }

--- a/src/client/components/common_editor/common_editor_utils.tsx
+++ b/src/client/components/common_editor/common_editor_utils.tsx
@@ -83,8 +83,14 @@ export async function getExistingHashes(locals: CommonFileLocal[]): Promise<stri
 }
 
 async function saveLocalFileSingle(local: CommonFileLocal): Promise<CommonFileSaved> {
+  const formData = new FormData();
+  formData.append('file', local.file);
   const fileUploadURL = getAPIPath({ kind: APIPath.FileUpload });
-  const response: AxiosResponse<FileUploadResponse> = await http.post(fileUploadURL, local.file);
+  const response: AxiosResponse<FileUploadResponse> = await http.post(fileUploadURL, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
 
   return {
     kind: EditorKind.Saved,

--- a/src/common/validation/task_validation.ts
+++ b/src/common/validation/task_validation.ts
@@ -67,7 +67,7 @@ const zTaskDataBatch = z.object({
   judge_file_name: z.string().min(1),
 });
 
-const zTaskSubtaskBatch = z.object({
+export const zTaskSubtaskBatch = z.object({
   id: z.string().uuid().optional(),
   name: z.string().min(1),
   score_max: z.number().nonnegative(),
@@ -96,7 +96,7 @@ const zTaskDataOutput = z.object({
   judge_file_name: z.string().min(1),
 });
 
-const zTaskSubtaskOutput = z.object({
+export const zTaskSubtaskOutput = z.object({
   id: z.string().uuid().optional(),
   name: z.string().min(1),
   score_max: z.number().nonnegative(),
@@ -123,7 +123,7 @@ const zTaskDataCommunication = z.object({
   judge_file_name: z.string().min(1),
 });
 
-const zTaskSubtaskCommunication = z.object({
+export const zTaskSubtaskCommunication = z.object({
   id: z.string().uuid().optional(),
   name: z.string().min(1),
   score_max: z.number().nonnegative(),

--- a/src/db/migrations/20240320074757_initial_migration.ts
+++ b/src/db/migrations/20240320074757_initial_migration.ts
@@ -201,8 +201,8 @@ export async function up(db: Kysely<any>): Promise<void> {
   await db.schema
     .createTable("verdict_subtasks")
     .addColumn("id", "uuid", (col) => col.primaryKey().defaultTo(sql`uuid_generate_v4()`))
-    .addColumn("verdict_id", "uuid", (col) => col.notNull().references("verdicts.id"))
-    .addColumn("subtask_id", "uuid", (col) => col.notNull().references("task_subtasks.id"))
+    .addColumn("verdict_id", "uuid", (col) => col.notNull().references("verdicts.id").onDelete('cascade'))
+    .addColumn("subtask_id", "uuid", (col) => col.notNull().references("task_subtasks.id").onDelete('cascade'))
     .addColumn("created_at", "timestamp", (col) => col.defaultTo(sql`now()`).notNull())
     .addColumn("verdict", "text")
     .addColumn("raw_score", "real")
@@ -216,7 +216,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn("verdict_subtask_id", "uuid", (col) =>
       col.notNull().references("verdict_subtasks.id")
     )
-    .addColumn("task_data_id", "uuid", (col) => col.notNull().references("task_data.id"))
+    .addColumn("task_data_id", "uuid", (col) => col.notNull().references("task_data.id").onDelete('cascade'))
     .addColumn("created_at", "timestamp", (col) => col.defaultTo(sql`now()`).notNull())
     .addColumn("verdict", "text")
     .addColumn("raw_score", "real")

--- a/src/server/authorization.ts
+++ b/src/server/authorization.ts
@@ -1,6 +1,11 @@
 import { SessionData } from "common/types";
+import { NextRequest } from "next/server";
+import { KOMPGEN_SECRET } from "./secrets";
 
-export function canManageTasks(session: SessionData | null): boolean {
+export function canManageTasks(session: SessionData | null, request: NextRequest | undefined = undefined): boolean {
+  if (request?.headers.get('Authorization') === KOMPGEN_SECRET) {
+    return true;
+  }
   if (session == null || session.user.role != 'admin') {
     return false;
   }

--- a/src/server/logic/tasks/update_editor_task.ts
+++ b/src/server/logic/tasks/update_editor_task.ts
@@ -248,6 +248,7 @@ export async function upsertTaskSubtasks(
   const subtasksOld = subtasksOrdered.filter((subtask) => subtask.id != null);
 
   const subtasksOldIds = subtasksOld.map((subtask) => subtask.id as string);
+  console.log('$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$', subtasksOldIds);
   if (subtasksOldIds.length <= 0) {
     await trx.deleteFrom("task_subtasks").where("task_id", "=", taskId).execute();
   } else {
@@ -257,6 +258,8 @@ export async function upsertTaskSubtasks(
       .where("id", "not in", subtasksOldIds)
       .execute();
   }
+  
+  console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
 
   const dbSubtasksNew =
     subtasksNew.length <= 0

--- a/src/server/logic/tasks/update_editor_task.ts
+++ b/src/server/logic/tasks/update_editor_task.ts
@@ -27,8 +27,7 @@ import {
   dbToTaskDataInteractiveDTO,
   dbToTaskDataOutputDTO,
 } from "./editor_utils";
-import { UUID } from "crypto";
-import { lookupFromSlugOrId } from "@root/api/v1/tasks/[id]/utils";
+
 
 type Ordered<T> = T & {
   order: number;

--- a/src/server/logic/tasks/update_editor_task.ts
+++ b/src/server/logic/tasks/update_editor_task.ts
@@ -248,7 +248,6 @@ export async function upsertTaskSubtasks(
   const subtasksOld = subtasksOrdered.filter((subtask) => subtask.id != null);
 
   const subtasksOldIds = subtasksOld.map((subtask) => subtask.id as string);
-  console.log('$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$', subtasksOldIds);
   if (subtasksOldIds.length <= 0) {
     await trx.deleteFrom("task_subtasks").where("task_id", "=", taskId).execute();
   } else {
@@ -258,8 +257,6 @@ export async function upsertTaskSubtasks(
       .where("id", "not in", subtasksOldIds)
       .execute();
   }
-  
-  console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
 
   const dbSubtasksNew =
     subtasksNew.length <= 0

--- a/src/server/logic/tasks/update_editor_task.ts
+++ b/src/server/logic/tasks/update_editor_task.ts
@@ -27,6 +27,8 @@ import {
   dbToTaskDataInteractiveDTO,
   dbToTaskDataOutputDTO,
 } from "./editor_utils";
+import { UUID } from "crypto";
+import { lookupFromSlugOrId } from "@root/api/v1/tasks/[id]/utils";
 
 type Ordered<T> = T & {
   order: number;
@@ -236,7 +238,7 @@ type UpsertTaskSubtasksResult = {
   subtasksWithData: TaskSubtaskWithData[];
 };
 
-async function upsertTaskSubtasks(
+export async function upsertTaskSubtasks(
   trx: Transaction<Models>,
   taskId: string,
   subtasks: TaskSubtaskDTO[]
@@ -331,7 +333,7 @@ type TaskDataWithExtras = TaskDataDTO & {
   order: number;
 };
 
-async function upsertTaskData(
+export async function upsertTaskData(
   trx: Transaction<Models>,
   subtasks: TaskSubtaskWithData[]
 ): Promise<Selectable<TaskDataTable>[]> {

--- a/src/server/secrets.ts
+++ b/src/server/secrets.ts
@@ -10,6 +10,8 @@ export const POSTGRES_HOSTNAME =
     ? process.env.DOCKER_POSTGRES_HOSTNAME
     : process.env.POSTGRES_HOSTNAME;
 
+export const KOMPGEN_SECRET = process.env.KOMPGEN_SECRET;
+
 export const POSTGRES_DB = process.env.POSTGRES_DB;
 export const POSTGRES_USER = process.env.POSTGRES_USER;
 export const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD;


### PR DESCRIPTION
Adds an endpoint which allows scripts (like kompgen) to create/update problems with their data and subtasks configured properly

Updating problems (through the kg endpoint) is a little weird if there were already submissions to some problem.
The old task_subtasks files for this task are all deleted (causing a cascading delete to task_data and verdict_task_data) and then replaced with the new one.

This leaves old submissions in a semi-awkward spot... which doesn't CRASH at least.  Here's a screenshot of what an old submission looks like after we edited the data (using the kg endpoint...)
![image](https://github.com/user-attachments/assets/a91131ce-ef80-49a4-9a51-9f1126461dbd)

TODO: proper rejudging in a separate PR