### PR TITLE
Fix stale browser state refreshed on login/logout

### DIFF
--- a/src/app/(auth)/login/login_page.tsx
+++ b/src/app/(auth)/login/login_page.tsx
@@ -36,8 +36,9 @@ const LoginPage: FunctionComponent = () => {
       throw new Error(response.data);
     }
     const homeURL = getPath({ kind: Path.Home });
-    router.push(homeURL);
     setSession(response.data);
+    router.push(homeURL);
+    router.refresh();
   }, [router, username, password, setSession]);
 
   const throttledLogin = useCallback(async () => {

--- a/src/app/(auth)/logout/page.tsx
+++ b/src/app/(auth)/logout/page.tsx
@@ -17,6 +17,7 @@ const Page: FunctionComponent = () => {
     http.delete("/api/v1/auth/logout").then(() => {
       setSession(null);
       router.push("/login");
+      router.refresh();
     });
   });
 

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -44,6 +44,7 @@ const Page: FunctionComponent = () => {
       }
 
       router.push("/login");
+      router.refresh();
     } catch (error) {}
 
     setThrottle(false);

--- a/src/client/components/navbar/index.tsx
+++ b/src/client/components/navbar/index.tsx
@@ -28,15 +28,15 @@ export const NavbarAccount = memo(() => {
   if (session == null || session.user == null) {
     return (
       <>
-        <NavbarLink href="/login" className="ml-auto">Login</NavbarLink>
-        <NavbarLink href="/register">Register</NavbarLink>
+        <NavbarLink href={getPath({kind: Path.AccountLogin })} className="ml-auto">Login</NavbarLink>
+        <NavbarLink href={getPath({kind: Path.AccountRegister })}>Register</NavbarLink>
       </>
     );
   }
   return (
     <>
       <div className="text-2xl px-1 py-3 ml-auto">{session?.user.name}</div>
-      <NavbarLink href="/logout">Logout</NavbarLink>
+      <NavbarLink href={getPath({kind: Path.AccountLogout })}>Logout</NavbarLink>
     </>
   );
 });

--- a/src/client/paths.ts
+++ b/src/client/paths.ts
@@ -3,6 +3,9 @@ import { uuidToHuradoID } from "common/utils/uuid";
 
 export enum Path {
   Home = "Home",
+  AccountLogin = "AccountLogin",
+  AccountLogout = "AccountLogout",
+  AccountRegister = "AccountRegister",
   Submission = "Submission",
   TaskList = "TaskList",
   TaskView = "TaskView",
@@ -16,6 +19,9 @@ export enum Path {
 
 export type PathArguments =
   | { kind: Path.Home }
+  | { kind: Path.AccountLogin }
+  | { kind: Path.AccountLogout }
+  | { kind: Path.AccountRegister }
   | { kind: Path.Submission; uuid: string }
   | { kind: Path.TaskList }
   | { kind: Path.TaskView; slug: string }
@@ -30,6 +36,12 @@ export function getPath(args: PathArguments) {
   switch (args.kind) {
     case Path.Home:
       return "/";
+    case Path.AccountLogin:
+      return "/login";
+    case Path.AccountLogout:
+      return "/logout";
+    case Path.AccountRegister:
+      return "/register";
     case Path.Submission:
       return `/submissions/${uuidToHuradoID(args.uuid)}`;
     case Path.TaskList:


### PR DESCRIPTION
NextJS very aggressively caches loaded pages. Calling `router.refresh()` on login and logout seem to be the simplest general fix. Still doesn't seem to let you refresh Page A automatically by following a link to Page B then a link back to Page A. ChatGPT seems to suggest the only way to get this done is through loading Page A client-side, which seems really dumb. But this isn't going to be fixed in this patch. This is just a general-purpose nuclear option because almost all pages will change because of a login/logout.