### PR TITLE
Support scale argument for images

### DIFF
--- a/src/common/latex/latex_images.tsx
+++ b/src/common/latex/latex_images.tsx
@@ -1,0 +1,62 @@
+import { CSSProperties, useEffect, useState } from "react";
+import { LatexArgument, LatexBaseNode, LatexNodeProps } from "./latex_types";
+import { latexBrokenInline, latexParseKwargs, latexPositionalString, latexGuardString } from "./latex_utils";
+
+export type LatexMacroImage = LatexBaseNode<{
+  type: "macro";
+  content: "includegraphics";
+  args?: LatexArgument[];
+}>
+
+export function LatexImageX({ node, source }: LatexNodeProps<LatexMacroImage>) {
+  const kwargs = latexParseKwargs(node, 0);
+
+  // Don't use the second arg yet
+  const src = latexPositionalString(node.args, 1);
+  if (src == null) {
+    return latexBrokenInline(node, source);
+  }
+
+  let scale: number | null = null;
+  const texScale = kwargs.scale && kwargs.scale.length > 0
+    ? kwargs.scale[0]
+    : null;
+
+    if (texScale && latexGuardString(texScale)) {
+    const parsedScale = +texScale.content;
+    scale = isNaN(parsedScale) ? null : parsedScale;
+  }
+
+  const [width, setWidth] = useState<number | undefined>(undefined);
+  const [ratio, setRatio] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    getImageDimensions(src).then(dimensions => {
+      const aspectRatio = dimensions.width / dimensions.height;
+      setRatio(aspectRatio);
+      setWidth(dimensions.width);
+    });
+  }, [src]);
+
+  const scaledWidth = width != null
+    ? scale != null ? width * scale : width
+    : undefined;
+
+    const style: CSSProperties = {
+    width: scaledWidth,
+    aspectRatio: ratio,
+  };
+
+  return <img style={style} className="max-w-full" src={src} />;
+}
+
+
+async function getImageDimensions(src: string): Promise<{ width: number, height: number }> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.src = src;
+    img.onload = () => {
+      resolve({ width: img.width, height: img.height });
+    };
+  });
+}

--- a/src/common/latex/latex_list.tsx
+++ b/src/common/latex/latex_list.tsx
@@ -180,7 +180,7 @@ function ListItem({ bullet: itemBullet, order, ordered, children }: ListItemProp
 }
 
 function ListOrdered({ node, source }: LatexNodeProps<LatexNodeList>) {
-  const kwargs = latexParseKwargs(node.args[0]);
+  const kwargs = latexParseKwargs(node, 0);
   const label = kwargs.label ?? null;
   const depth = useContext(ListOrderedDepthContext);
   const children = latexEnvironmentListChildren(node, source, true);
@@ -197,7 +197,7 @@ function ListOrdered({ node, source }: LatexNodeProps<LatexNodeList>) {
 }
 
 function ListUnordered({ node, source }: LatexNodeProps<LatexNodeList>) {
-  const kwargs = latexParseKwargs(node.args[0]);
+  const kwargs = latexParseKwargs(node, 0);
   const label = kwargs.label ?? null;
   const depth = useContext(ListUnorderedDepthContext);
   const children = latexEnvironmentListChildren(node, source, false);

--- a/src/common/latex/latex_render.tsx
+++ b/src/common/latex/latex_render.tsx
@@ -20,6 +20,7 @@ import 'katex/dist/katex.css';
 import { LatexBulletOrdered, latexEnvironmentList, LatexMacroBulletOrdered, LatexNodeList } from "./latex_list";
 import { latexBrokenBlock, latexBrokenInline, latexPositionalString } from "./latex_utils";
 import { LatexSyntaxHighlight } from "./latex_syntax_highlight";
+import { LatexImageX, LatexMacroImage } from "./latex_images";
 
 const LatexParser = getParser({
   macros: LATEX_MACROS,
@@ -200,14 +201,8 @@ function LatexNodeMacroX({ node, source }: LatexNodeProps<LatexNodeMacro>): Reac
       }
       return latexBrokenInline(node, source);
     }
-    case "includegraphics": {
-      // Don't use the second arg yet
-      const src = latexPositionalString(node.args, 1);
-      if (src == null) {
-        return latexBrokenInline(node, source);
-      }
-      return <img className="max-w-full mx-auto" src={src} />;
-    }
+    case "includegraphics":
+      return <LatexImageX node={node as LatexMacroImage} source={source} />;
     case "$":
     case "%":
       return node.content;
@@ -222,6 +217,7 @@ function LatexNodeMacroX({ node, source }: LatexNodeProps<LatexNodeMacro>): Reac
     default:
       // Functionally useless type assertion
       UnreachableCheck(node.content)
+      // It's important to return the content here. This allows for users to escape special strings using \x
       return node.content;
   }
 }
@@ -229,7 +225,7 @@ function LatexNodeMacroX({ node, source }: LatexNodeProps<LatexNodeMacro>): Reac
 function LatexNodeEnvironmentX({ node, source }: LatexNodeProps<LatexNodeEnvironment>) {
   switch (node.env) {
     case "center":
-      return <div className="text-center">{renderEnvironmentContent(node, source)}</div>;
+      return <div className="flex flex-col items-center text-center">{renderEnvironmentContent(node, source)}</div>;
     case "enumerate":
     case "itemize":
       return latexEnvironmentList(node as LatexNodeList, source);

--- a/src/common/latex/latex_utils.tsx
+++ b/src/common/latex/latex_utils.tsx
@@ -1,4 +1,4 @@
-import { LatexArgument, LatexNode, LatexNodeMacro, LatexNodeString } from "./latex_types";
+import { LatexArgument, LatexNode, LatexNodeEnvironment, LatexNodeMacro, LatexNodeString } from "./latex_types";
 
 
 export function latexBrokenInline(node: LatexNodeMacro, source: string) {
@@ -39,17 +39,73 @@ export function latexPositionalArgument(args: LatexArgument[] | undefined, index
   return arg.content;
 }
 
-export function latexParseKwargs(arg: LatexArgument | undefined): Record<string, LatexNode[] | undefined> {
-  if (arg == null) {
+export function latexParseKwargs(node: LatexNodeMacro | LatexNodeEnvironment, index: number): Record<string, LatexNode[]> {
+  // Something is strange with the parser. For some reason, it splits the content into multiple nodes
+  // if it finds a '=' for environments, so you'll get ["key1", "=", "value1", ",", " ", "key2", "=", "value2"]
+  // But if it's a macro, the args will be ["key2=value2, key2=value2"]
+  // This function handles both cases
+
+  if (node.args == null || node.args.length <= index) {
     return {};
   }
 
-  function isEqualString(node: LatexNode, content: string): boolean {
-    return node.type == "string" && node.content == content;
+  const arg = node.args[index];
+
+  // Look for any strings in the content that contain "=" and split them into multiple nodes
+  const processed: LatexNode[] = [];
+  for (const child of arg.content) {
+    if (!latexGuardString(child) || isExactlyNodeString(child, "=") || !child.content.includes("=")) {
+      processed.push(child);
+      continue;
+    }
+    const pieces = splitBySymbol(child, "=");
+    processed.push(...pieces);
   }
 
+  return kwargsFromNodes(processed);
+}
+
+
+function splitBySymbol(original: LatexNodeString, symbol: string): LatexNode[] {
+  const pieces: LatexNode[] = [];
+  let offset = 0;
+
+  function doPushPart(part: string) {
+    if (part.length == 0) {
+      return;
+    }
+    pieces.push({
+      type: "string",
+      content: part,
+      position: {
+        start: {
+          line: original.position.start.line,
+          column: original.position.start.column + offset,
+          offset: original.position.start.offset + offset,
+        },
+        end: {
+          line: original.position.start.line,
+          column: original.position.start.column + offset + part.length,
+          offset: original.position.start.offset + offset + part.length,
+        },
+      }
+    });
+    offset += part.length;
+  }
+
+  const parts = original.content.split(symbol);
+  parts.forEach((part, idx) => {
+    if (idx > 0) {
+      doPushPart(symbol);
+    }
+    doPushPart(part);
+  });
+
+  return pieces;
+}
+
+function kwargsFromNodes(content: LatexNode[]): Record<string, LatexNode[]> {
   const kwargs: Record<string, LatexNode[]> = {};
-  const content = arg.content;
   let idx = 0;
   while (idx < content.length) {
     if (idx + 2 >= content.length) {
@@ -58,13 +114,13 @@ export function latexParseKwargs(arg: LatexArgument | undefined): Record<string,
 
     const current = content[idx];
     const next = content[idx + 1];
-    if (latexGuardString(current) && isEqualString(next, "=")) {
+    if (latexGuardString(current) && isExactlyNodeString(next, "=")) {
       idx += 2;
       const key = current.content;
       const value: LatexNode[] = [];
       while (idx < content.length) {
         const node = content[idx];
-        if (isEqualString(node, ",")) {
+        if (isExactlyNodeString(node, ",")) {
           idx++;
           break;
         }
@@ -79,6 +135,10 @@ export function latexParseKwargs(arg: LatexArgument | undefined): Record<string,
   return kwargs;
 }
 
-function latexGuardString(node: LatexNode): node is LatexNodeString {
+export function latexGuardString(node: LatexNode): node is LatexNodeString {
   return node.type == "string";
+}
+
+function isExactlyNodeString(node: LatexNode, content: string): boolean {
+  return node.type == "string" && node.content == content;
 }


### PR DESCRIPTION
Does not allow you to exceed container boundaries. But allows you to shrink images by a fixed multiplier of its original size.