### PR TITLE
Improve Deployment Tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,5 +136,9 @@ dist
 /volumes
 /private
 
+# Build artifacts
+/build
+/build.bak
+
 # For the mac users out there
 .DS_Store

--- a/config/production/docker-compose.production.yml
+++ b/config/production/docker-compose.production.yml
@@ -5,7 +5,7 @@ services:
     container_name: hurado-main
     image: noiph/hurado:latest
     working_dir: /app
-    command: node /app/.next/standalone/server.js
+    command: node /app/build/standalone/server.js
     environment:
       - IS_UNDER_DOCKER=true
     env_file:
@@ -62,4 +62,4 @@ services:
     volumes:
       - ./config/production/nginx/:/etc/nginx/
       - ./private/nginx-certs/:/etc/nginx-certs/
-      - ./.next/:/var/www/hurado/:ro
+      - ./build/:/var/www/hurado/:ro

--- a/scripts/hrd.sh
+++ b/scripts/hrd.sh
@@ -1,7 +1,8 @@
-#! /bin/bash
+#!/bin/bash
 # Simple bash script that provides a few utilities for managing Hurado development/deployment
 
 PROJECT_ROOT=$(cd `dirname "$0"` && git rev-parse --show-toplevel)
+HRD_CMD=$PROJECT_ROOT/scripts/hrd.sh
 
 
 function hrd_install() {
@@ -130,7 +131,7 @@ function hrd_deploy() {
 
     case "$1" in
         production)
-            hrd connect production hrd deploy_serverside
+            $HRD_CMD connect production hrd deploy_server
             ;;
         *)
             echo "Unknown server: $1"
@@ -139,14 +140,14 @@ function hrd_deploy() {
     esac
 }
 
-function hrd_deploy_serverside() {
+function hrd_deploy_server() {
     # Server-side script for deploying the latest changes to the production server
     set -e
     cd /hurado/
     git pull --ff-only origin main
     ./scripts/next_build.sh
-    hrd compose restart
-    hrd shell npm run db:migrate
+    $HRD_CMD compose restart
+    $HRD_CMD shell npm run db:migrate
 }
 
 
@@ -178,7 +179,7 @@ function hrd_main() {
             ;;
         deploy_server)
             shift
-            hrd_deploy_serverside $@
+            hrd_deploy_server $@
             ;;
         *)
             echo "Usage: hrd {install|compose|shell|sql|connect|deploy}"

--- a/scripts/next_build.sh
+++ b/scripts/next_build.sh
@@ -22,6 +22,12 @@ function run_outside() {
         -v "$PROJECT_ROOT:/app" \
         -w /app \
         noiph/hurado:latest ./scripts/next_build.sh inside
+
+    if [ -d "$PROJECT_ROOT/build.bak" ]; then
+        rm -rf "$PROJECT_ROOT/build.bak"
+    fi
+    mv "$PROJECT_ROOT/build" "$PROJECT_ROOT/build.bak"
+    mv "$PROJECT_ROOT/.next" "$PROJECT_ROOT/build"
 }
 
 

--- a/scripts/next_build.sh
+++ b/scripts/next_build.sh
@@ -26,7 +26,9 @@ function run_outside() {
     if [ -d "$PROJECT_ROOT/build.bak" ]; then
         rm -rf "$PROJECT_ROOT/build.bak"
     fi
-    mv "$PROJECT_ROOT/build" "$PROJECT_ROOT/build.bak"
+    if [ -d "$PROJECT_ROOT/build" ]; then
+        mv "$PROJECT_ROOT/build" "$PROJECT_ROOT/build.bak"
+    fi
     mv "$PROJECT_ROOT/.next" "$PROJECT_ROOT/build"
 }
 


### PR DESCRIPTION
Changes:
* Deployment no longer uses the `./.next/` directory directly.
  * The build artifacts are moved to `./build/` so that future builds don't run over existing deployments.
  * The most recent build artifacts are moved to `./build.bak` just in case rolling back is needed.
* Fixed non-working `hrd` references inside `hrd.sh` script