### PR TITLE
Add LaTeX string replacement "macros"

### DIFF
--- a/src/common/latex/latex_macros.tsx
+++ b/src/common/latex/latex_macros.tsx
@@ -1,3 +1,5 @@
+import type React from "react";
+
 type EnvInfo = {
   renderInfo?: {
     inMathMode?: boolean;
@@ -121,3 +123,14 @@ export const LATEX_ENVIRONMENTS = {
     signature: "o",
   },
 } satisfies Record<string, EnvInfo>;
+
+export const LATEX_STRINGS = {
+  "``": () => {
+    return <>&ldquo;</>;
+  },
+  "''": () => {
+    return <>&rdquo;</>;
+  },
+  "--": () => <>&ndash;</>,
+  "---": () => <>&mdash;</>,
+} satisfies Record<string, React.ComponentType>;

--- a/src/common/latex/latex_postprocess.ts
+++ b/src/common/latex/latex_postprocess.ts
@@ -1,0 +1,132 @@
+import { UnreachableDefault } from "common/errors";
+import {
+  LatexArgument,
+  LatexNode,
+  LatexNodeMacro,
+} from "./latex_types";
+import { LatexNodeStringLike, latexProcessStringLike } from "./latex_strings";
+import { Arrays } from "common/utils/arrays";
+
+export function latexProcessNode(node: LatexNode): LatexNode {
+  switch (node.type) {
+    case "comment":
+      return node;
+    case "whitespace":
+      return node;
+    case "string":
+      return node;
+    case "inlinemath":
+      return node;
+    case "displaymath":
+      return node;
+    case "parbreak":
+      return node;
+    case "macro":
+      return latexProcessMacro(node);
+    case "environment":
+      return {
+        ...node,
+        content: latexProcessContentStrings(node.content),
+      };
+    case "verbatim":
+      return node;
+    case "group":
+      return {
+        ...node,
+        content: latexProcessContentStrings(node.content),
+      };
+    case "root":
+      return {
+        ...node,
+        content: latexProcessContentStrings(node.content),
+      };
+    default:
+      // Functionally useless type assertion
+      UnreachableDefault(node);
+      return node;
+  }
+}
+
+export function latexProcessMacro(node: LatexNodeMacro): LatexNodeMacro {
+  let merged: LatexNodeMacro;
+  if (node.args == null) {
+    merged = node;
+  } else {
+    merged = {
+      ...node,
+      args: node.args.map(mergeArgumentStrings),
+    };
+  }
+
+  switch(merged.content) {
+    case "url": {
+      return latexProcessVerbatimArgument(merged, 0);
+    }
+    case "href": {
+      return latexProcessVerbatimArgument(merged, 0);
+    }
+    default:
+      return merged;
+  }
+}
+
+export function latexProcessVerbatimArgument(node: LatexNodeMacro, index: number): LatexNodeMacro {
+  // Looks at an argument, for example \macro{my-argument-with-nonsense-characters}
+  // Then returns "my-argument-with-nonsense-characters" as a string literal
+  if (node.args == null) {
+    return node;
+  }
+
+  const args = node.args;
+  function extractVerbatim() {
+    return args[index];
+  }
+
+  return {
+    ...node,
+    args: Arrays.replaceNth(node.args, index, extractVerbatim()),
+  };
+}
+
+function mergeArgumentStrings(arg: LatexArgument): LatexArgument {
+  return {
+    ...arg,
+    content: latexProcessContentStrings(arg.content),
+  };
+}
+
+function latexProcessContentStrings(content: LatexNode[]): LatexNode[] {
+  // Concatenates all string-like nodes and runs custom post-processing on them
+  // All macros, groups, and other latex nodes are also considered delimiters.
+  // They are post-processed in-and-of themselves and injected into the final result
+  // without getting merged into any string-like concatenations.
+  //
+  // Read the code of `latexProcessStringLike` to understand what our post-processing does.
+  // In short, it splits out magic substrings from long latex strings.
+
+  const result: LatexNode[] = [];
+  const running: LatexNodeStringLike[] = [];
+
+  for (const child of content) {
+    if (child.type == "string") {
+      running.push(child);
+    } else if (child.type == "whitespace") {
+      running.push(child);
+    } else {
+      if (running.length > 0) {
+        const pieces = latexProcessStringLike(running);
+        result.push(...pieces);
+        // Empty out the array
+        running.length = 0;
+      }
+      result.push(latexProcessNode(child));
+    }
+  }
+
+  if (running.length > 0) {
+    const pieces = latexProcessStringLike(running);
+    result.push(...pieces);
+  }
+
+  return result;
+}

--- a/src/common/latex/latex_strings.ts
+++ b/src/common/latex/latex_strings.ts
@@ -1,124 +1,165 @@
-import { UnreachableDefault } from "common/errors";
+import { UnreachableError } from "common/errors";
 import {
-  LatexArgument,
-  LatexNode,
   LatexNodeString,
   LatexNodeWhitespace,
   NodePoint,
 } from "./latex_types";
+import { LATEX_STRINGS } from "./latex_macros";
 
-export function mergeLatexNodeStrings(node: LatexNode): LatexNode {
-  switch (node.type) {
-    case "comment":
-      return node;
-    case "whitespace":
-      return node;
-    case "string":
-      return node;
-    case "inlinemath":
-      return node;
-    case "displaymath":
-      return node;
-    case "parbreak":
-      return node;
-    case "macro":
-      if (node.args == null) {
-        return node;
-      }
-      return {
-        ...node,
-        args: node.args.map(mergeArgumentStrings),
-      };
-    case "environment":
-      return {
-        ...node,
-        content: mergeContentStrings(node.content),
-      };
-    case "group":
-      return {
-        ...node,
-        content: mergeContentStrings(node.content),
-      };
-    case "root":
-      return {
-        ...node,
-        content: mergeContentStrings(node.content),
-      };
-    default:
-      // Functionally useless type assertion
-      UnreachableDefault(node);
-      return node;
+export type LatexNodeStringLike = LatexNodeString | LatexNodeWhitespace;
+
+type StringFragment = {
+  char: string;
+  startLine: number;
+  startColumn: number;
+  startOffset: number;
+  endLine: number;
+  endColumn: number;
+  endOffset: number;
+};
+
+type FragmentSplit = {
+  start: number;
+  end: number;
+};
+
+type MagicSubstring = keyof typeof LATEX_STRINGS;
+const MAGIC_SUBSTRINGS = Object.keys(LATEX_STRINGS) as MagicSubstring[];
+
+
+export function latexProcessStringLike(nodes: LatexNodeStringLike[]): LatexNodeStringLike[] {
+  // This function concatenates all nodes into one giant string
+  // Then it looks for all substrings in a magic dictionary and splits by that
+  // Essentially if the dictionary is ["mp", "str"] and the nodes are ["exam", "plestr", "ingstrong"]
+  // The result should be ["exa", "mp", "le", "str", "ing", "str", "ong"]
+  // There's just a lot of bookkeeping to keep track of string positions 
+
+  // Chop everything up into fragments
+  const fragments: StringFragment[] = [];
+  for (const node of nodes) {
+    if (node.type === "string") {
+      fragments.push(...fragmentBreakdown(node));
+    } else if (node.type === "whitespace") {
+      fragments.push(fragmentWhitespace(node));
+    } else {
+      throw new UnreachableError(node);
+    }
   }
+
+  // Find all occurrences of all MAGIC_SUBSTRINGs. This may have many overlapping occurrences
+  const occurrences = findOccurrences(fragments, MAGIC_SUBSTRINGS);
+  // Remove all overlapping occurrences by greedy algorithm
+  const pruned = pruneSplits(occurrences);
+  // Create a linear list of splits that cover the entire range
+  const linear = linearizeSplits(fragments, pruned);
+  // Extract the fragments for reconstruction
+  const splits = linear.map(occ => extractSplit(fragments, occ));
+  // Reconstruct the LatexNodes from the fragments
+  return splits.map(split => fragmentReconstruct(split));
 }
 
-function mergeArgumentStrings(arg: LatexArgument): LatexArgument {
+function fragmentBreakdown(node: LatexNodeString): StringFragment[] {
+  const fragments: StringFragment[] = [];
+  for (let i = 0; i < node.content.length; i++) {
+    fragments.push({
+      char: node.content[i],
+      startLine: node.position.start.line,
+      startColumn: node.position.start.column + i,
+      startOffset: node.position.start.offset + i,
+      endLine: node.position.start.line,
+      endColumn: node.position.start.column + i,
+      endOffset: node.position.start.offset + i,
+    });
+  }
+  return fragments;
+}
+
+function fragmentWhitespace(node: LatexNodeWhitespace): StringFragment {
+  // Make a fragment from a Whitespace node.
+  // This intentionally returns the same shape as fragmentBreakdown for v8 optimization purposes
   return {
-    ...arg,
-    content: mergeContentStrings(arg.content),
+    char: ' ',
+    startLine: node.position.start.line,
+    startColumn: node.position.start.column,
+    startOffset: node.position.start.offset,
+    endLine: node.position.end.line,
+    endColumn: node.position.end.column,
+    endOffset: node.position.end.offset,
   };
 }
 
-function mergeContentStrings(content: LatexNode[]): LatexNode[] {
-  const result: LatexNode[] = [];
-  const running: (LatexNodeString | LatexNodeWhitespace)[] = [];
+function fragmentReconstruct(fragments: StringFragment[]): LatexNodeStringLike {
+  const content = fragments.map(f => f.char).join("");
+  const first = fragments[0];
+  const start: NodePoint = {
+    line: first.startLine,
+    column: first.startColumn,
+    offset: first.startOffset,
+  };
 
-  for (const child of content) {
-    if (child.type == "string") {
-      running.push(child);
-    } else if (child.type == "whitespace") {
-      running.push(child);
-    } else {
-      if (running.length > 0) {
-        const str = mergeStrings(running);
-        result.push(str);
-        // Empty out the array
-        running.length = 0;
-      }
-      result.push(mergeLatexNodeStrings(child));
-    }
-  }
+  const last = fragments[fragments.length - 1];
+  const end: NodePoint = {
+    line: last.endLine,
+    column: last.endColumn,
+    offset: last.endOffset,
+  };
 
-  if (running.length > 0) {
-    const str = mergeStrings(running);
-    result.push(str);
-    // Empty out the array
-    running.length = 0;
-  }
-
-  return result;
-}
-
-function mergeStrings(nodes: (LatexNodeString | LatexNodeWhitespace)[]): LatexNode {
-  let start: NodePoint = nodes[0].position.start;
-  let end: NodePoint = nodes[0].position.end;
-
-  const running: string[] = [];
-  for (const node of nodes) {
-    if (node.position.start.offset < start.offset) {
-      start = node.position.start;
-    }
-    if (node.position.end.offset >= end.offset) {
-      end = node.position.end;
-    }
-    running.push(node.type == "string" ? node.content : " ");
-  }
-  const combined = running.join("").replace("\\s+", " ");
-  if (combined == " ") {
+  if (content.match(/\\s+/)) {
     return {
       type: "whitespace",
       position: {
         start,
         end,
       },
-    };
+    };    
   } else {
     return {
       type: "string",
-      content: combined,
+      content,
       position: {
         start,
         end,
       },
     };
   }
+}
+
+function pruneSplits(splits: FragmentSplit[]): FragmentSplit[] {
+  // Runs a greedy algorithm to remove overlaps among splits
+  // This prioritizes splits that start first
+  // In case of ties, it prioritizes splits that end last
+  return splits.sort((a, b) => {
+    const diffStart = a.start - b.start;
+    if (diffStart != 0) {
+      return diffStart;
+    }
+    return b.end - a.end;
+  });
+}
+
+function linearizeSplits(fragments: StringFragment[], splits: FragmentSplit[]): FragmentSplit[] {
+  // Creates a linear list of splits so that all fragments are covered
+  const points = new Set<number>();
+  points.add(0);
+  points.add(fragments.length);
+  for (const split of splits) {
+    points.add(split.start);
+    points.add(split.end);
+  }
+  const sorted = points.keys().toArray().toSorted();
+  const result: FragmentSplit[] = [];
+  for (let i = 1; i < sorted.length; i++) {
+    result.push({ start: sorted[i-1], end: sorted[i] });
+  }
+  return result;
+}
+
+function extractSplit(fragments: StringFragment[], split: FragmentSplit): StringFragment[] {
+  return fragments.slice(split.start, split.end);
+}
+
+function findOccurrences(fragments: StringFragment[], dictionary: string[]): FragmentSplit[] {
+  // Runs the Aho Corasick algorithm to find all occurrences of all dictionary strings
+  // Each occurrence is tracked as a FragmentSplit which notes the indices where it starts ane ends
+  return [];
 }

--- a/src/common/latex/latex_strings.ts
+++ b/src/common/latex/latex_strings.ts
@@ -23,16 +23,83 @@ type FragmentSplit = {
   end: number;
 };
 
-type MagicSubstring = keyof typeof LATEX_STRINGS;
-const MAGIC_SUBSTRINGS = Object.keys(LATEX_STRINGS) as MagicSubstring[];
+class TrieNode {
+  // TrieNode for the Aho-Corasick Algorithm
 
+  children: Record<string, TrieNode>;
+  fail: TrieNode | null;
+  output: string[];
+
+  constructor() {
+    this.children = {};  // map from character -> TrieNode
+    this.fail = null;    // the "failure link" (points to another TrieNode)
+    this.output = [];    // list of patterns that end at this node
+  }
+
+  static build(dictionary: string[]): TrieNode {
+    const root = new TrieNode();
+
+    // 1. Insert all dictionary words into the trie
+    for (const word of dictionary) {
+      let current = root;
+      for (const c of word) {
+        if (!current.children[c]) {
+          current.children[c] = new TrieNode();
+        }
+        current = current.children[c];
+      }
+      // Once we’ve inserted the full word, mark the output on that final node
+      current.output.push(word);
+    }
+
+    // 2. Build the failure links using BFS
+    const queue: TrieNode[] = [];
+
+    // For each child of root, its fail link is root itself
+    for (const c in root.children) {
+      const child = root.children[c];
+      child.fail = root;
+      queue.push(child);
+    }
+
+    // BFS to build the rest of the failure links
+    while (queue.length > 0) {
+      const current = queue.shift() as TrieNode;
+      // For each possible edge from 'current'
+      for (const c in current.children) {
+        const child = current.children[c];
+        // Find the fail link for this child
+        let failCandidate = current.fail;
+
+        // Follow fail links until we find a node with the same character or we reach root
+        while (failCandidate && !(c in failCandidate.children)) {
+          failCandidate = failCandidate.fail;
+        }
+
+        // If we found a node with the same character, set child.fail to that node's child
+        child.fail = failCandidate
+          ? failCandidate.children[c]
+          : root;
+
+        // Merge output patterns (if the fail link node has them, we add them)
+        child.output = child.output.concat(child.fail.output);
+
+        queue.push(child);
+      }
+    }
+
+    return root;
+  }
+}
+
+const LATEX_STRINGS_TRIE = TrieNode.build(Object.keys(LATEX_STRINGS));
 
 export function latexProcessStringLike(nodes: LatexNodeStringLike[]): LatexNodeStringLike[] {
   // This function concatenates all nodes into one giant string
   // Then it looks for all substrings in a magic dictionary and splits by that
   // Essentially if the dictionary is ["mp", "str"] and the nodes are ["exam", "plestr", "ingstrong"]
   // The result should be ["exa", "mp", "le", "str", "ing", "str", "ong"]
-  // There's just a lot of bookkeeping to keep track of string positions 
+  // There's just a lot of bookkeeping to keep track of string positions
 
   // Chop everything up into fragments
   const fragments: StringFragment[] = [];
@@ -47,7 +114,7 @@ export function latexProcessStringLike(nodes: LatexNodeStringLike[]): LatexNodeS
   }
 
   // Find all occurrences of all MAGIC_SUBSTRINGs. This may have many overlapping occurrences
-  const occurrences = findOccurrences(fragments, MAGIC_SUBSTRINGS);
+  const occurrences = findOccurrences(fragments, LATEX_STRINGS_TRIE);
   // Remove all overlapping occurrences by greedy algorithm
   const pruned = pruneSplits(occurrences);
   // Create a linear list of splits that cover the entire range
@@ -111,7 +178,7 @@ function fragmentReconstruct(fragments: StringFragment[]): LatexNodeStringLike {
         start,
         end,
       },
-    };    
+    };
   } else {
     return {
       type: "string",
@@ -128,13 +195,22 @@ function pruneSplits(splits: FragmentSplit[]): FragmentSplit[] {
   // Runs a greedy algorithm to remove overlaps among splits
   // This prioritizes splits that start first
   // In case of ties, it prioritizes splits that end last
-  return splits.sort((a, b) => {
+  const sorted = splits.toSorted((a, b) => {
     const diffStart = a.start - b.start;
     if (diffStart != 0) {
       return diffStart;
     }
     return b.end - a.end;
   });
+  let highest = -1;
+  const pruned: FragmentSplit[] = [];
+  for (const split of sorted) {
+    if (split.start >= highest) {
+      pruned.push(split);
+      highest = split.end;
+    }
+  }
+  return pruned;
 }
 
 function linearizeSplits(fragments: StringFragment[], splits: FragmentSplit[]): FragmentSplit[] {
@@ -146,7 +222,8 @@ function linearizeSplits(fragments: StringFragment[], splits: FragmentSplit[]): 
     points.add(split.start);
     points.add(split.end);
   }
-  const sorted = points.keys().toArray().toSorted();
+  // Watch out! Javascript sorting is really dumb
+  const sorted = points.keys().toArray().toSorted((a, b) => a - b);
   const result: FragmentSplit[] = [];
   for (let i = 1; i < sorted.length; i++) {
     result.push({ start: sorted[i-1], end: sorted[i] });
@@ -158,8 +235,38 @@ function extractSplit(fragments: StringFragment[], split: FragmentSplit): String
   return fragments.slice(split.start, split.end);
 }
 
-function findOccurrences(fragments: StringFragment[], dictionary: string[]): FragmentSplit[] {
+function findOccurrences(fragments: StringFragment[], root: TrieNode): FragmentSplit[] {
   // Runs the Aho Corasick algorithm to find all occurrences of all dictionary strings
   // Each occurrence is tracked as a FragmentSplit which notes the indices where it starts ane ends
-  return [];
+  const results: FragmentSplit[] = [];
+
+  let current = root;
+
+  for (let i = 0; i < fragments.length; i++) {
+    const c = fragments[i].char;
+
+    // Follow fail links if there's no matching child
+    while (current && !(c in current.children)) {
+      current = current.fail!;
+    }
+
+    // If current is null, reset to root
+    if (!current) {
+      current = root;
+    } else {
+      // Move to the matching child
+      current = current.children[c];
+    }
+
+    // If we've ended up in a node that has output (meaning a dictionary word ends here)
+    if (current.output.length > 0) {
+      // Each output word is found at the index `i`
+      for (const word of current.output) {
+        const endIndex = i + 1;
+        const startIndex = i - word.length + 1;
+        results.push({ start: startIndex, end: endIndex });
+      }
+    }
+  }
+  return results;
 }


### PR DESCRIPTION
We now have the following substitutions:
* ` `` ` => `&ldquo;`
* ` '' ` => `&rdquo;`
* ` -- ` => `&ndash;`
* ` --- ` => `&mdash;`
