### PR TITLE
LenientChecker now ignores whitespace mismatches

### DIFF
--- a/src/server/evaluation/judge_checker.ts
+++ b/src/server/evaluation/judge_checker.ts
@@ -27,7 +27,7 @@ export async function checkSubmissionOutput(opts: {
   const outputPath = path.join(opts.output_root, opts.output_file_name);
   switch (checker.kind) {
     case CheckerKind.LenientDiff: {
-      const diffStatus = await runChildProcess(["diff", judgePath, outputPath]);
+      const diffStatus = await runChildProcess(["diff", "-b", judgePath, outputPath]);
       if (diffStatus == 0) {
         return {
           verdict: Verdict.Accepted,


### PR DESCRIPTION
So if the answer is "a  b\n", then "a     b" will also be accepted