### PR TITLE
Fix C++ submissions

### DIFF
--- a/src/server/evaluation/judge_compile.ts
+++ b/src/server/evaluation/judge_compile.ts
@@ -106,7 +106,7 @@ export async function compileLocalSource(
   const timeLimit = `${timeLimitSeconds}`;
   const wallTimeLimit = `${getWallTimeLimit(timeLimitSeconds)}`;
   const memLimit = memory_limit_byte != null
-    ? `${memory_limit_byte / 1000}`
+    ? `${Math.floor(memory_limit_byte / 1000)}`
     : `${LIMITS_DEFAULT_COMPILE_MEMORY_LIMIT_KB}`;
 
   return IsolateUtils.with(async (isolate) => {

--- a/src/server/evaluation/judge_compile.ts
+++ b/src/server/evaluation/judge_compile.ts
@@ -119,7 +119,7 @@ export async function compileLocalSource(
       `--time=${timeLimit}`,
       `--wall-time=${wallTimeLimit}`,
       `--mem=${memLimit}`,
-      "--processes=8",
+      "--processes=4",
       "--run",
       "--",
       ...command,

--- a/src/server/evaluation/judge_compile.ts
+++ b/src/server/evaluation/judge_compile.ts
@@ -119,7 +119,7 @@ export async function compileLocalSource(
       `--time=${timeLimit}`,
       `--wall-time=${wallTimeLimit}`,
       `--mem=${memLimit}`,
-      "--processes=1",
+      "--processes=8",
       "--run",
       "--",
       ...command,


### PR DESCRIPTION
- Fixed: Compile memory limit is also floor-divided; that arg must be an integer
- Fixed: Compiler still gives `g++: fatal error: cannot execute '/usr/lib/gcc/x86_64-linux-gnu/10/cc1plus': vfork: Resource temporarily unavailable` when i try to compile
