### PR TITLE
Fix eslint to actually work

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     ecmaFeatures: {
       jsx: true,
     },
+    warnOnUnsupportedTypeScriptVersion: false,
   },
   plugins: ["@typescript-eslint"],
   extends: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,16 +3,21 @@ module.exports = {
   parserOptions: {
     project: "./tsconfig.json",
     tsconfigRootDir: __dirname,
+    ecmaVersion: 2020,
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
   plugins: ["@typescript-eslint"],
-  extends: ["eslint:recommended", "next/core-web-vitals", "prettier"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "next/core-web-vitals",
+    "prettier"
+  ],
   rules: {
-    "no-console": [
-      "warn",
-      {
-        allow: ["info", "warn", "error"],
-      },
-    ],
+    "no-console": "off",
     "no-unused-vars": "off",
     "consistent-return": "off",
     "import/extensions": ["error", "never"],
@@ -44,5 +49,6 @@ module.exports = {
     ],
     "react/react-in-jsx-scope": "off",
     "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-non-null-assertion": "off",
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-next": "14.1.4",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-interactive": "^11.1.0",
         "nodemon": "^3.1.4",
         "postcss": "^8.4.41",
         "prettier": "^3.2.5",
@@ -6234,6 +6235,48 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -6492,6 +6535,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6693,6 +6746,153 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
       "license": "MIT"
+    },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.36.0.tgz",
+      "integrity": "sha512-3T/PUdKTCnkUmhQU6FFJEHsLwadsRegktX3TNHk+2JJB9HlA8gp1/VXblXVDI93kSnXF2rdPx0GMbHtJIV2LPg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/boxicons": {
       "version": "2.1.4",
@@ -7028,6 +7228,48 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -7042,6 +7284,61 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -7114,6 +7411,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -7122,6 +7426,13 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/common-path-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7722,6 +8033,20 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -8136,6 +8461,48 @@
         }
       }
     },
+    "node_modules/eslint-interactive": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-interactive/-/eslint-interactive-11.1.0.tgz",
+      "integrity": "sha512-qiZax3rbugRE1AzeUPSM0MAybdvSnou4rVDfz3J3r6LdNKtmepYNL/F/pfMprypj9Ejhwht0CgzUrqTVc8H7og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "boxen": "^8.0.1",
+        "chalk": "^5.3.0",
+        "comlink": "^4.4.1",
+        "enquirer": "^2.4.1",
+        "estraverse": "^5.3.0",
+        "find-cache-dir": "^5.0.0",
+        "is-installed-globally": "^1.0.0",
+        "ora": "^8.1.0",
+        "table": "^6.8.2",
+        "terminal-link": "^3.0.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "eslint-interactive": "bin/eslint-interactive.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.45.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-interactive/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/eslint-module-utils": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
@@ -8541,6 +8908,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
@@ -8597,6 +8981,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-5.0.0.tgz",
+      "integrity": "sha512-OuWNfjfP05JcpAP3JPgAKUhWefjMRfI5iAoSsvE24ANYWJaepAtlSgWECSVEuRgSXpyNEc9DJwG/TZpgcOqyig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "common-path-prefix": "^3.0.0",
+        "pkg-dir": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-up": {
@@ -8786,6 +9187,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
@@ -8916,6 +9340,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globals": {
@@ -9234,6 +9674,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -9549,6 +9999,49 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-installed-globally/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -9708,6 +10201,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakmap": {
@@ -10133,6 +10639,56 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10241,6 +10797,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -10736,6 +11305,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10752,6 +11337,97 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/os-tmpdir": {
@@ -11157,6 +11833,110 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+      "integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/yocto-queue": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -11745,6 +12525,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -11790,6 +12590,23 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reusify": {
@@ -12249,6 +13066,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -12296,6 +13131,19 @@
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
@@ -12631,6 +13479,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -12687,6 +13549,69 @@
         "node": ">= 10"
       }
     },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -12733,6 +13658,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/terminal-link": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-3.0.0.tgz",
+      "integrity": "sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^5.0.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-link/node_modules/ansi-escapes": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-link/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/text-table": {
@@ -13389,6 +14360,76 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -13490,6 +14531,16 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -13508,6 +14559,57 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,8 @@
         "@types/node": "20.11.24",
         "@types/pg": "^8.11.6",
         "@types/react": "^18.2.61",
+        "@typescript-eslint/eslint-plugin": "^5.62.0",
+        "@typescript-eslint/parser": "^5.62.0",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -62,8 +64,7 @@
         "server-only": "^0.0.1",
         "tailwindcss": "^3.4.9",
         "ts-node": "^10.9.2",
-        "typescript": "^5.5.4",
-        "typescript-eslint": "^8.0.1"
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -5602,34 +5603,167 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/unist": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4"
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/type-utils": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -5638,179 +5772,31 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.19.1.tgz",
-      "integrity": "sha512-Rp7k9lhDKBMRJB/nM9Ksp1zs4796wVNyihG9/TU9R6KCJDNkQbc2EOKjrBtLYh3396ZdpXLtr/MkaSEmNMtykw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.19.1",
-        "@typescript-eslint/utils": "8.19.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.1.tgz",
-      "integrity": "sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.1.tgz",
-      "integrity": "sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.1.tgz",
-      "integrity": "sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "eslint-visitor-keys": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/ts-api-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
-      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5818,23 +5804,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5846,36 +5831,10 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5883,186 +5842,20 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.19.1.tgz",
-      "integrity": "sha512-IxG5gLO0Ne+KaUc8iW1A+XuKLd63o4wlbI1Zp692n1xojCl/THvgIKXJXBZixTh5dd5+yTJ/VXH7GJaaw21qXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.19.1",
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/typescript-estree": "8.19.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.1.tgz",
-      "integrity": "sha512-60L9KIuN/xgmsINzonOcMDSB8p82h95hoBfSBtXuO4jlR1R9L1xSkmVZKgCPVfavDlXihh4ARNjXhh1gGnLC7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.1.tgz",
-      "integrity": "sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.1.tgz",
-      "integrity": "sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.1.tgz",
-      "integrity": "sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "eslint-visitor-keys": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/ts-api-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
-      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10573,6 +10366,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/next": {
       "version": "14.2.23",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.23.tgz",
@@ -13028,19 +12828,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.2.0"
-      }
-    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -13129,6 +12916,29 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -13246,226 +13056,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/typescript-eslint": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.19.1.tgz",
-      "integrity": "sha512-LKPUQpdEMVOeKluHi8md7rwLcoXHhwvWp3x+sJkMuq3gGm9yaYJtPo8sRZSblMFJ5pcOGCAak/scKf1mvZDlQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.19.1",
-        "@typescript-eslint/parser": "8.19.1",
-        "@typescript-eslint/utils": "8.19.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.19.1.tgz",
-      "integrity": "sha512-tJzcVyvvb9h/PB96g30MpxACd9IrunT7GF9wfA9/0TJ1LxGOJx1TdPzSbBBnNED7K9Ka8ybJsnEpiXPktolTLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.19.1",
-        "@typescript-eslint/type-utils": "8.19.1",
-        "@typescript-eslint/utils": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.19.1.tgz",
-      "integrity": "sha512-67gbfv8rAwawjYx3fYArwldTQKoYfezNUT4D5ioWetr/xCrxXxvleo3uuiFuKfejipvq+og7mjz3b0G2bVyUCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.19.1",
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/typescript-estree": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.1.tgz",
-      "integrity": "sha512-60L9KIuN/xgmsINzonOcMDSB8p82h95hoBfSBtXuO4jlR1R9L1xSkmVZKgCPVfavDlXihh4ARNjXhh1gGnLC7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.1.tgz",
-      "integrity": "sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.1.tgz",
-      "integrity": "sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.1.tgz",
-      "integrity": "sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "eslint-visitor-keys": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/ts-api-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
-      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-next": "14.1.4",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-interactive": "^11.1.0",
     "nodemon": "^3.1.4",
     "postcss": "^8.4.41",
     "prettier": "^3.2.5",
@@ -92,5 +93,6 @@
     "tailwindcss": "^3.4.9",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "@types/node": "20.11.24",
     "@types/pg": "^8.11.6",
     "@types/react": "^18.2.61",
+    "@typescript-eslint/eslint-plugin": "^5.62.0",
+    "@typescript-eslint/parser": "^5.62.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.0",
     "eslint-config-airbnb": "^19.0.4",
@@ -89,7 +91,6 @@
     "server-only": "^0.0.1",
     "tailwindcss": "^3.4.9",
     "ts-node": "^10.9.2",
-    "typescript": "^5.5.4",
-    "typescript-eslint": "^8.0.1"
+    "typescript": "^5.5.4"
   }
 }

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "server/sessions";
-import { ForgotPasswordPage } from "./forgot-password-page";
 import { DefaultLayout } from "client/components/layouts/default_layout";
+import { ForgotPasswordPage } from "./forgot-password-page";
 
 export const metadata: Metadata = {
   title: "Forgot Password",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,8 +2,8 @@ import type { FunctionComponent } from "react";
 import { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "server/sessions";
-import LoginPage from "./login_page";
 import { DefaultLayout } from "client/components/layouts/default_layout";
+import LoginPage from "./login_page";
 
 export const metadata: Metadata = {
   title: "Login",

--- a/src/app/(auth)/password-reset/page.tsx
+++ b/src/app/(auth)/password-reset/page.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "server/sessions";
-import { PasswordResetPage } from "./password-reset-page";
 import { DefaultLayout } from "client/components/layouts/default_layout";
+import { PasswordResetPage } from "./password-reset-page";
 
 export const metadata: Metadata = {
   title: "Password Reset",

--- a/src/app/(auth)/password-reset/password-reset-page.tsx
+++ b/src/app/(auth)/password-reset/password-reset-page.tsx
@@ -22,6 +22,7 @@ import {
 import { zUserResetPassword } from "common/validation/user_validation";
 import { applyValidationErrors, ResponseKind } from "common/responses";
 import { UnreachableCheck } from "common/errors";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { ResetPasswordError, ResetPasswordSuccess } from "@root/api/v1/auth/reset-password/route";
 
 type PasswordResetForm = {

--- a/src/app/admin/contests/page.tsx
+++ b/src/app/admin/contests/page.tsx
@@ -25,6 +25,7 @@ type ContestSummaryAdminDTO = {
   created_at: Date;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 async function getContestsData(session: SessionData): Promise<ContestSummaryAdminDTO[]> {
   const contests = await db
     .selectFrom("contests")

--- a/src/app/admin/sets/page.tsx
+++ b/src/app/admin/sets/page.tsx
@@ -26,6 +26,7 @@ type ProblemSetSummaryAdminDTO = {
   order: number;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 async function getProblemSetsData(session: SessionData): Promise<ProblemSetSummaryAdminDTO[]> {
   const sets = await db
     .selectFrom("problem_sets")

--- a/src/app/admin/tasks/page.tsx
+++ b/src/app/admin/tasks/page.tsx
@@ -25,6 +25,7 @@ type TaskSummaryAdminDTO = {
   created_at: Date;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 async function getTasksData(session: SessionData): Promise<TaskSummaryAdminDTO[]> {
   const tasks = await db
     .selectFrom("tasks")

--- a/src/app/api/v1/auth/register/route.ts
+++ b/src/app/api/v1/auth/register/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { cookies } from "next/headers";
 import { db } from "db";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { SessionData, UserPublic } from "common/types";
 import { tokenizeSession } from "server/sessions";
 import { createUser } from "server/logic/users";

--- a/src/app/api/v1/auth/register/route.ts
+++ b/src/app/api/v1/auth/register/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { cookies } from "next/headers";
 import { db } from "db";
 import { SessionData, UserPublic } from "common/types";
 import { tokenizeSession } from "server/sessions";
 import { createUser } from "server/logic/users";
 import { zUserRegister } from "common/validation/user_validation";
 import { APISuccessResponse, APIValidationErrorType, customValidationError, makeSuccessResponse, zodValidationError } from "common/responses";
-import { cookies } from "next/headers";
 
 
 export type UserRegisterError = APIValidationErrorType<typeof zUserRegister>;

--- a/src/app/api/v1/auth/reset-password/route.ts
+++ b/src/app/api/v1/auth/reset-password/route.ts
@@ -62,6 +62,7 @@ export async function POST(request: NextRequest) {
 }
 
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 function censorEmail(email: string): string {
   const [username, domain] = email.split("@");
   // Show only the first two characters of the username

--- a/src/app/api/v1/submissions/route.ts
+++ b/src/app/api/v1/submissions/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { db } from "db";
 import {
   APIForbiddenError,
@@ -17,7 +18,6 @@ import { LIMITS_DEFAULT_SUBMISSION_SIZE_LIMIT_BYTE } from "server/evaluation/jud
 import { createSubmission, SubmissionFileCreate } from "server/logic/submissions/create_submission";
 import { getSession } from "server/sessions";
 import { enqueueSubmissionJudgement } from "worker/queue";
-import { z } from "zod";
 
 type CreateSubmissionValidationErrors = {
   request: true,

--- a/src/app/api/v1/tasks/[id]/kg/route.ts
+++ b/src/app/api/v1/tasks/[id]/kg/route.ts
@@ -83,11 +83,13 @@ async function updateKgTask(task: KgTaskDTO) {
       ])
       .executeTakeFirstOrThrow();
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
     const { subtasks: dbSubtasks, subtasksWithData } = await upsertTaskSubtasks(
       trx,
       task.id,
       task.subtasks
     );
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
     const dbTaskData = await upsertTaskData(trx, subtasksWithData);
 
     return {

--- a/src/app/api/v1/tasks/[id]/kg/route.ts
+++ b/src/app/api/v1/tasks/[id]/kg/route.ts
@@ -1,12 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { TaskType } from "common/types/constants";
 import { REGEX_SLUG } from "common/validation/common_validation";
 import { zTaskSubtaskBatch, zTaskSubtaskCommunication, zTaskSubtaskOutput } from "common/validation/task_validation";
 import { db } from "db";
-import { NextRequest, NextResponse } from "next/server";
 import { canManageTasks } from "server/authorization";
 import { upsertTaskData, upsertTaskSubtasks } from "server/logic/tasks/update_editor_task";
 import { getSession } from "server/sessions";
-import { z } from "zod";
 
 // Updates only a subset of the properties that kg knows about, and
 //   DOESN'T OVERWRITE THE OTHER PROPERTIES!!!

--- a/src/app/api/v1/tasks/[id]/score_overall/route.ts
+++ b/src/app/api/v1/tasks/[id]/score_overall/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { canManageTasks } from "server/authorization";
 import { getSession } from "server/sessions";
 import { NextContext } from "types/nextjs";

--- a/src/app/api/v1/tasks/[id]/submissions/route.ts
+++ b/src/app/api/v1/tasks/[id]/submissions/route.ts
@@ -1,7 +1,7 @@
+import { NextRequest, NextResponse } from "next/server";
 import { Language, Verdict } from "common/types/constants";
 import { SubmissionSummaryDTO } from "common/types/submissions";
 import { db } from "db";
-import { NextRequest, NextResponse } from "next/server";
 import { canManageTasks } from "server/authorization";
 import { getSession } from "server/sessions";
 import { NextContext } from "types/nextjs";

--- a/src/app/api/v1/tasks/files/hashes/route.ts
+++ b/src/app/api/v1/tasks/files/hashes/route.ts
@@ -1,8 +1,8 @@
-import { db } from "db";
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { db } from "db";
 import { canManageTasks } from "server/authorization";
 import { getSession } from "server/sessions";
-import { z } from "zod";
 
 const schema = z.array(z.string());
 

--- a/src/app/api/v1/tasks/files/route.ts
+++ b/src/app/api/v1/tasks/files/route.ts
@@ -7,6 +7,7 @@ import { TaskFileStorage } from "server/files";
 import { getSession } from "server/sessions";
 
 function isFile(obj: FormDataEntryValue): obj is File {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
   return typeof (obj as any)['arrayBuffer'] === 'function';
 }
 

--- a/src/app/api/v1/tasks/simple/route.ts
+++ b/src/app/api/v1/tasks/simple/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { zTaskCreateSimple } from "common/validation/task_validation";
 import { db } from "db";
 import { getSession } from "server/sessions";
@@ -13,7 +14,6 @@ import {
   makeSuccessResponse,
   zodValidationError,
 } from "common/responses";
-import { z } from "zod";
 
 export type TaskCreateSimpleError =
   | APIForbiddenErrorType

--- a/src/app/api/v1/tasks/simple/route.ts
+++ b/src/app/api/v1/tasks/simple/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { z } from "zod";
 import { zTaskCreateSimple } from "common/validation/task_validation";
 import { db } from "db";

--- a/src/app/api/v1/user/submissions/route.ts
+++ b/src/app/api/v1/user/submissions/route.ts
@@ -1,7 +1,7 @@
+import { NextRequest, NextResponse } from "next/server";
 import { Language, Verdict } from "common/types/constants";
 import { SubmissionSummaryDTO } from "common/types/submissions";
 import { db } from "db";
-import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "server/sessions";
 
 export async function GET(request: NextRequest) {

--- a/src/app/contests/[slug]/page.tsx
+++ b/src/app/contests/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { db } from "db";
 import { DefaultLayout } from "client/components/layouts/default_layout";
 import { canManageContests } from "server/authorization";
 import { getSession } from "server/sessions";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { ContestViewerDTO, TaskScoredSummaryDTO, TaskSummaryDTO } from "common/types";
 import { ContestViewer } from "client/components/contest_viewer/contest_viewer";
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,15 @@
 import "@root/global.css";
 import "react-toastify/dist/ReactToastify.css";
-import HuradoPNG from "assets/images/hurado.png"
 import { Montserrat, Roboto, Space_Mono } from "next/font/google";
 
 import type { FunctionComponent, ReactNode } from "react";
 import type { Metadata } from "next";
 import { ToastContainer, Zoom } from "react-toastify";
 
+import classNames from "classnames";
 import { SessionProvider } from "client/sessions";
 import { getSession } from "server/sessions";
-import classNames from "classnames";
+import HuradoPNG from "assets/images/hurado.png"
 
 const fontMontserrat = Montserrat({
   subsets: ["latin"],

--- a/src/app/sets/[slug]/page.tsx
+++ b/src/app/sets/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { cache } from "react";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { ProblemSetViewerDTO, TaskScoredSummaryDTO, TaskSummaryDTO } from "common/types";
 import { db } from "db";
 import { DefaultLayout } from "client/components/layouts/default_layout";

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,5 +1,6 @@
 import { db } from "db";
 import { TaskCard } from "client/components/cards";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { TaskScoredSummaryDTO, TaskSummaryDTO } from "common/types";
 import { DefaultLayout } from "client/components/layouts/default_layout";
 import { EmptyNoticePage } from "client/components/empty_notice";

--- a/src/client/components/admin_table/admin_table.tsx
+++ b/src/client/components/admin_table/admin_table.tsx
@@ -1,11 +1,11 @@
 import { DetailedHTMLProps, HTMLAttributes, TableHTMLAttributes } from "react";
+import classNames from "classnames";
 import { DefaultLayout } from "client/components/layouts/default_layout";
 import { getSession } from "server/sessions";
 import { ForbiddenPage } from "server/errors/forbidden";
 import { canManageContests } from "server/authorization";
 import { ContestSummaryDTO } from "common/types";
 import { db } from "db";
-import classNames from "classnames";
 
 type TableProps = DetailedHTMLProps<HTMLAttributes<HTMLTableElement>, HTMLTableElement>;
 type TableSectionProps = DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;

--- a/src/client/components/admin_table/admin_table.tsx
+++ b/src/client/components/admin_table/admin_table.tsx
@@ -1,10 +1,17 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { DetailedHTMLProps, HTMLAttributes, TableHTMLAttributes } from "react";
 import classNames from "classnames";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { DefaultLayout } from "client/components/layouts/default_layout";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { getSession } from "server/sessions";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { ForbiddenPage } from "server/errors/forbidden";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { canManageContests } from "server/authorization";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { ContestSummaryDTO } from "common/types";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { db } from "db";
 
 type TableProps = DetailedHTMLProps<HTMLAttributes<HTMLTableElement>, HTMLTableElement>;

--- a/src/client/components/auth/auth.tsx
+++ b/src/client/components/auth/auth.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
   DetailedHTMLProps,
@@ -10,6 +11,7 @@ import {
   LabelHTMLAttributes,
 } from 'react';
 import { FieldError } from 'react-hook-form';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import Link, { LinkProps } from 'next/link';
 import styles from './auth.module.css';
 
@@ -81,6 +83,7 @@ export function AuthLabel(props: AuthLabelProps) {
 
 type AuthInputProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const AuthInput = forwardRef<HTMLInputElement, AuthInputProps>((props, ref) => {
   return (
     <input

--- a/src/client/components/auth/auth.tsx
+++ b/src/client/components/auth/auth.tsx
@@ -10,8 +10,8 @@ import {
   LabelHTMLAttributes,
 } from 'react';
 import { FieldError } from 'react-hook-form';
-import styles from './auth.module.css';
 import Link, { LinkProps } from 'next/link';
+import styles from './auth.module.css';
 
 type AuthMainProps = DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
 

--- a/src/client/components/cards/common_card.tsx
+++ b/src/client/components/cards/common_card.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import Link from "next/link";
+import classNames from "classnames";
 import { ContestSummaryDTO, ProblemSetSummaryDTO, TaskScoredSummaryDTO, TaskSummaryDTO } from "common/types";
 import { getPath, Path } from "client/paths";
-import classNames from "classnames";
 
 type CommonCardProps = {
   url: string;
@@ -66,7 +66,7 @@ export function TaskCard({ task }: TaskCardProps) {
   const url = getPath({ kind: Path.TaskView, slug: task.slug });
 
   let top_class = "p-[1rem] border-t border-l border-r border-black rounded-tl-2xl rounded-tr-2xl group-hover:bg-gray-150";
-  let bottom_class = "p-0 bg-[#cccccc] border-l border-r border-b border-black rounded-bl-2xl rounded-br-2xl overflow-hidden";
+  const bottom_class = "p-0 bg-[#cccccc] border-l border-r border-b border-black rounded-bl-2xl rounded-br-2xl overflow-hidden";
   let pbar_class = "p-[0.25rem]";
   let pbar_style = {};
 

--- a/src/client/components/cards/common_card.tsx
+++ b/src/client/components/cards/common_card.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import classNames from "classnames";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { ContestSummaryDTO, ProblemSetSummaryDTO, TaskScoredSummaryDTO, TaskSummaryDTO } from "common/types";
 import { getPath, Path } from "client/paths";
 

--- a/src/client/components/common_editor/common_editor_attachments.tsx
+++ b/src/client/components/common_editor/common_editor_attachments.tsx
@@ -94,6 +94,7 @@ const CommonAttachmentLocalX = ({
   );
 
   const onBlurPath = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
     (_event: InputChangeEvent) => {
       setAttachments(
         Arrays.replaceNth(attachments, index, {
@@ -107,6 +108,7 @@ const CommonAttachmentLocalX = ({
 
   const onClickDelete = useCallback(() => {
     setAttachments([...attachments.slice(0, index), ...attachments.slice(index + 1)]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [index, attachment, setAttachments]);
 
   return (
@@ -176,6 +178,7 @@ export function CommonEditorAttachments({
       return;
     }
     pickerRef.current.click();
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [attachments, setAttachments]);
 
   return (

--- a/src/client/components/common_editor/common_editor_attachments.tsx
+++ b/src/client/components/common_editor/common_editor_attachments.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { ReactNode, useCallback, useRef } from "react";
+import { toast } from "react-toastify";
 import { Arrays } from "common/utils/arrays";
 import { InputChangeEvent } from "common/types/events";
 import { normalizeAttachmentPath } from "common/utils/attachments";
@@ -19,7 +20,6 @@ import {
 } from "./common_editor_parts";
 import { destructivelyComputeSHA1 } from "./common_editor_utils";
 import styles from "./common_editor.module.css";
-import { toast } from "react-toastify";
 
 type CommonAttachmentSavedProps = {
   index: number;

--- a/src/client/components/common_editor/common_editor_parts.tsx
+++ b/src/client/components/common_editor/common_editor_parts.tsx
@@ -67,6 +67,7 @@ type CommonEditorFooterProps<T> = {
   saveObject(object: T): Promise<SaveResult<T>>;
 };
 
+// eslint-disable-next-line @typescript-eslint/ban-types -- pre-existing error before eslint inclusion
 export const CommonEditorFooter = <T extends {}>({
   initial,
   object,
@@ -95,6 +96,7 @@ export const CommonEditorFooter = <T extends {}>({
     } finally {
       setSaving(false);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [object, saveObject]);
 
   return (
@@ -355,10 +357,12 @@ export const CommonEditorFileInput = (props: CommonEditorFileInputProps) => {
       destructivelyComputeSHA1(newFile);
       onFileChange(newFile, curr.name);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [file, filename, onFileChange]);
 
   const onFileRemove = useCallback(() => {
     onFileChange(null, "");
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [file, filename, onFileChange]);
 
   const onNameChange = useCallback(

--- a/src/client/components/common_editor/common_editor_parts.tsx
+++ b/src/client/components/common_editor/common_editor_parts.tsx
@@ -10,14 +10,14 @@ import {
   PropsWithChildren,
   useRef,
 } from "react";
+import { toast } from "react-toastify";
 import BoxIcon from "client/components/box_icon";
 import { InputChangeEvent, SelectChangeEvent, TextAreaChangeEvent } from "common/types/events";
+import { getPath, Path } from "client/paths";
+import { Scrollable } from "../scrollable";
 import { destructivelyComputeSHA1, IncompleteHashesException } from "./common_editor_utils";
 import styles from "./common_editor.module.css";
-import { Scrollable } from "../scrollable";
-import { toast } from "react-toastify";
 import { CommonFileED, CommonFileLocal, EditorKind } from "./types";
-import { getPath, Path } from "client/paths";
 
 type CommonEditorPageProps = {
   isStatement: boolean;

--- a/src/client/components/common_editor/common_editor_statement.tsx
+++ b/src/client/components/common_editor/common_editor_statement.tsx
@@ -27,6 +27,7 @@ export const CommonEditorStatement = ({ task, statement, setStatement }: CommonE
     (value: string | undefined) => {
       setStatement(value ?? "");
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [statement, setStatement]
   );
 

--- a/src/client/components/common_editor/common_editor_statement.tsx
+++ b/src/client/components/common_editor/common_editor_statement.tsx
@@ -4,9 +4,9 @@ import MonacoEditor from "@monaco-editor/react";
 import { useCallback } from "react";
 import { Scrollable } from "client/components/scrollable";
 import { LatexDisplay } from "client/components/latex_display";
-import styles from "./common_editor.module.css";
 import { TaskED } from "../task_editor/types";
 import { SampleIODisplay } from "../sample_io_display/sample_io_display";
+import styles from "./common_editor.module.css";
 
 const MonacoOptions: editor.IStandaloneEditorConstructionOptions = {
   language: 'latex',

--- a/src/client/components/common_editor/common_editor_tabs.tsx
+++ b/src/client/components/common_editor/common_editor_tabs.tsx
@@ -36,6 +36,7 @@ type CommonEditorTabProps = {
   children: ReactNode;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const CommonEditorTabComponent = memo(({ children }: CommonEditorTabProps) => {
   return (
     <div className={classNames(styles.tabs, "flex flex-row justify-start flex-none mb-1 mx-3 gap-2")}>

--- a/src/client/components/common_editor/common_editor_utils.tsx
+++ b/src/client/components/common_editor/common_editor_utils.tsx
@@ -27,6 +27,7 @@ export function useSimpleStringPropUpdater<T>(object: T, setObject: (obj: T) => 
         [key]: event.target.value,
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [object, setObject]
   );
 }
@@ -58,6 +59,7 @@ export function saveLocalFiles(
         },
       });
     } else {
+      // eslint-disable-next-line no-async-promise-executor -- pre-existing error before eslint inclusion
       return new Promise<CommonFileSaveResult>(async (resolve, reject) => {
         try {
           const saved = await saveLocalFileSingle(local);

--- a/src/client/components/contest_creator/contest_creator.tsx
+++ b/src/client/components/contest_creator/contest_creator.tsx
@@ -27,6 +27,7 @@ export function ContestCreator() {
 
   const onButtonClick = useCallback(() => {
     setShowModal(true);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [showModal]);
 
   const onModalHide = useCallback(() => {

--- a/src/client/components/contest_editor/contest_coercion.ts
+++ b/src/client/components/contest_editor/contest_coercion.ts
@@ -1,10 +1,10 @@
-import { ContestED, ContestTaskED } from "./types";
-import { CommonAttachmentED, EditorKind } from "../common_editor";
 import {
   ContestAttachmentEditorDTO,
   ContestEditorDTO,
   ContestTaskEditorDTO,
 } from "common/validation/contest_validation";
+import { CommonAttachmentED, EditorKind } from "../common_editor";
+import { ContestED, ContestTaskED } from "./types";
 
 export function coerceContestED(dto: ContestEditorDTO): ContestED {
   const contest: ContestED = {

--- a/src/client/components/contest_editor/contest_editor.tsx
+++ b/src/client/components/contest_editor/contest_editor.tsx
@@ -14,11 +14,11 @@ import {
   CommonEditorPage,
 } from "client/components/common_editor";
 import commonStyles from "client/components/common_editor/common_editor.module.css";
+import { getPath, Path } from "client/paths";
 import { ContestED } from "./types";
 import { saveContest } from "./contest_editor_saving";
 import { coerceContestED } from "./contest_coercion";
 import { ContestEditorDetails } from "./contest_editor_details";
-import { getPath, Path } from "client/paths";
 import { ContestEditorAdvanced } from "./contest_editor_advanced";
 
 type ContestEditorProps = {

--- a/src/client/components/contest_editor/contest_editor.tsx
+++ b/src/client/components/contest_editor/contest_editor.tsx
@@ -112,6 +112,7 @@ type ContestEditorTabProps = {
   slug: string;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const ContestEditorTabComponent = memo(({ tab, slug }: ContestEditorTabProps) => {
   const viewURL = getPath({ kind: Path.ContestView, slug: slug });
 

--- a/src/client/components/contest_editor/contest_editor_advanced.tsx
+++ b/src/client/components/contest_editor/contest_editor_advanced.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
+import { InputChangeEvent } from "common/types/events";
 import { CommonEditorContent, CommonEditorDetails, CommonEditorLabel } from "../common_editor";
 import { ContestED } from "./types";
-import { InputChangeEvent } from "common/types/events";
 
 type ContestEditorAdvancedProps = {
   contest: ContestED;

--- a/src/client/components/contest_editor/contest_editor_details.tsx
+++ b/src/client/components/contest_editor/contest_editor_details.tsx
@@ -18,6 +18,7 @@ import {
   CommonEditorTableHeader,
   CommonEditorContent,
 } from "client/components/common_editor";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { ButtonClickEvent, InputChangeEvent } from "common/types/events";
 import { Arrays } from "common/utils/arrays";
 import http from "client/http";
@@ -80,6 +81,7 @@ function ContestEditorAttachments({ contest, setContest }: ContestEditorAttachme
         attachments,
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [contest]
   );
 
@@ -119,6 +121,7 @@ export const ContestEditorTasks = ({ contest, setContest }: ContestEditorTasksPr
         },
       ],
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [contest]);
 
   return (
@@ -165,6 +168,7 @@ const ContestTaskEditor = ({ task, taskIndex, contest, setContest }: ContestTask
         tasks: Arrays.replaceNth(contest.tasks, taskIndex, newTask),
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [contest, taskIndex]
   );
 
@@ -288,6 +292,7 @@ const ContestTaskPicker = (props: ContestTaskPickerProps) => {
     } finally {
       setSearching(false);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [searching, text]);
 
   const onTaskClear = useCallback(() => {

--- a/src/client/components/contest_editor/contest_editor_details.tsx
+++ b/src/client/components/contest_editor/contest_editor_details.tsx
@@ -1,5 +1,8 @@
 import classNames from "classnames";
 import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { AxiosError, AxiosResponse } from "axios";
+import { toast } from "react-toastify";
 import { APIPath, getAPIPath, getPath, Path } from "client/paths";
 import {
   CommonEditorAttachments,
@@ -17,13 +20,10 @@ import {
 } from "client/components/common_editor";
 import { ButtonClickEvent, InputChangeEvent } from "common/types/events";
 import { Arrays } from "common/utils/arrays";
+import http from "client/http";
+import { TaskLookupDTO } from "common/types";
 import { ContestED, ContestTaskED, ContestTaskTaskED } from "./types";
 import styles from "./contest_editor.module.css";
-import Link from "next/link";
-import http from "client/http";
-import { AxiosError, AxiosResponse } from "axios";
-import { TaskLookupDTO } from "common/types";
-import { toast } from "react-toastify";
 
 type ContestEditorDetailsProps = {
   contest: ContestED;

--- a/src/client/components/contest_editor/contest_editor_saving.tsx
+++ b/src/client/components/contest_editor/contest_editor_saving.tsx
@@ -53,6 +53,7 @@ export async function saveContest(contest: ContestED): Promise<SaveResult<Contes
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 function validateContest(contest: ContestED): string[] {
   return [];
 }

--- a/src/client/components/contest_viewer/contest_viewer.tsx
+++ b/src/client/components/contest_viewer/contest_viewer.tsx
@@ -13,6 +13,7 @@ type ContestTitleDisplayProps = {
   className?: string;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const ContestViewerTitle = memo(({ title, className }: ContestTitleDisplayProps) => {
   return (
     <div

--- a/src/client/components/empty_notice/empty_notice.tsx
+++ b/src/client/components/empty_notice/empty_notice.tsx
@@ -49,6 +49,7 @@ function GooglyEyes() {
       window.removeEventListener("mousemove", onMouseMove);
       window.removeEventListener("touchmove", onTouchMove);
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, []);
 
   return (
@@ -88,6 +89,7 @@ export function EmptyNotice({ className }: EmptyNoticeProps) {
     <div className={classNames(className, "text-center w-fit mx-auto py-12 px-6 rounded-lg border border-gray-800")}>
       <GooglyEyes/>
       <div className="max-w-96 mt-6 mx-auto text-gray-800">
+        {/* eslint-disable-next-line react/no-unescaped-entities -- pre-existing error before eslint inclusion */}
         We searched everywhere, but there's nothing to see here right now. Please come back later.
       </div>
     </div>

--- a/src/client/components/empty_notice/empty_notice.tsx
+++ b/src/client/components/empty_notice/empty_notice.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { CSSProperties, useCallback, useEffect, useRef, useState } from "react";
-import styles from './empty_notice.module.css';
 import classNames from "classnames";
+import styles from './empty_notice.module.css';
 
 type MouseLocation = {
   x: number;

--- a/src/client/components/footer/index.tsx
+++ b/src/client/components/footer/index.tsx
@@ -12,11 +12,13 @@ type NavbarProps = {
   className?: string;
 };
 
+// eslint-disable-next-line react/display-name, @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 export const Footer = memo(({ className }: NavbarProps) => {
   return (
     <footer className="bg-blue-400 text-white p-4 lg:px-12">
       <div className="flex flex-col md:flex-row gap-2 w-full max-w-[64rem] px-4 mx-auto">
         <a href="https://noi.ph" target="_blank" className="self-center hover:opacity-80">
+          {/* eslint-disable-next-line @next/next/no-img-element -- pre-existing error before eslint inclusion */}
           <img src={NoiphBlueless.src} alt="Logo" className="w-20" />
         </a>
         <div className="text-neutral-800 text-sm font-light self-center w-1/2 text-center mx-auto md:w-1/3 md:text-start md:mx-0 mb-3 md:mb-0">
@@ -61,6 +63,7 @@ type FooterLinkProps = {
   children?: React.ReactNode;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 const FooterLink = ({ href, className, children }: FooterLinkProps) => {
   return (
     <Link className={classNames("text-2xl px-1 py-3 hover:text-blue-200", className)} href={href}>

--- a/src/client/components/form/form.tsx
+++ b/src/client/components/form/form.tsx
@@ -9,6 +9,7 @@ export function FormLabel(props: DetailedHTMLProps<InputHTMLAttributes<HTMLLabel
 
 type HTMLInputProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const FormInput = forwardRef<HTMLInputElement, HTMLInputProps>((props, ref) => {
   return <input {...props} ref={ref} className={classNames('block w-full border-b border-gray-500', props.className)}/>;
 });

--- a/src/client/components/homepage/homepage.tsx
+++ b/src/client/components/homepage/homepage.tsx
@@ -60,6 +60,7 @@ const Features = () => {
     <div className="bg-blue-450 px-6 pt-10 pb-6">
       <div className="max-w-[64rem] mx-auto">
         <h2 className="text-white text-4xl font-semibold text-center mb-4">
+          {/* eslint-disable-next-line react/no-unescaped-entities -- pre-existing error before eslint inclusion */}
           What's in Hurado?
         </h2>
         <div className="flex flex-col gap-4 justify-center lg:flex-row lg:justify-around mx-12">
@@ -91,6 +92,7 @@ const Faqs = () => {
         <div className="">
           <FaqItem>
             <FaqQuestion>
+              {/* eslint-disable-next-line react/no-unescaped-entities -- pre-existing error before eslint inclusion */}
               What is an "online judge"?
             </FaqQuestion>
             <FaqAnswer>
@@ -102,6 +104,7 @@ const Faqs = () => {
               Why would anyone want to do this?
             </FaqQuestion>
             <FaqAnswer>
+              {/* eslint-disable-next-line react/no-unescaped-entities -- pre-existing error before eslint inclusion */}
               It's fun! And educational!
             </FaqAnswer>
           </FaqItem>
@@ -143,6 +146,7 @@ type SponsorItemProps = {
 const SponsorItem = ({ name, logo }: SponsorItemProps) => {
   return (
     <div className="flex flex-col items-center mb-4">
+      {/* eslint-disable-next-line @next/next/no-img-element -- pre-existing error before eslint inclusion */}
       <img src={logo} alt={`${name} logo`} className="w-32 h-32 mb-4"/>
       <div className="text-black text-xl font-semibold">
         {name}

--- a/src/client/components/homepage/homepage.tsx
+++ b/src/client/components/homepage/homepage.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import Link from "next/link";
+import { ComponentType, DetailedHTMLProps, HTMLAttributes, ReactNode } from "react";
 import { getPath, Path } from "client/paths";
 import FreeSVG from 'assets/icons/free.svg';
 import FastSVG from 'assets/icons/fast.svg';
@@ -7,10 +8,9 @@ import ChallengeSVG from 'assets/icons/challenge.svg';
 import CreativeSVG from 'assets/icons/creative.svg';
 import DOSTSEI from 'assets/images/dost-sei.png'
 import { Navbar } from "../navbar";
+import { Footer } from "../footer";
 import styles from "./homepage.module.css";
 import { FaqAnswer, FaqItem, FaqQuestion } from "./homepage_faq";
-import { Footer } from "../footer";
-import { ComponentType, DetailedHTMLProps, HTMLAttributes, ReactNode } from "react";
 
 
 const HeroBanner = () => {

--- a/src/client/components/latex_display/latex_display.tsx
+++ b/src/client/components/latex_display/latex_display.tsx
@@ -6,10 +6,12 @@ type LatexDisplayProps = {
   children: string;
 };
 
+// eslint-disable-next-line react/display-name, @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 export const LatexDisplay = memo(({ className, children }: LatexDisplayProps) => {
   const result = renderLatex(children);
 
   if ('error' in result) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
     const error = result.error as any;
     return (
       <div className="font-mono text-red-500">

--- a/src/client/components/layouts/admin_layout.tsx
+++ b/src/client/components/layouts/admin_layout.tsx
@@ -1,4 +1,5 @@
 import { Navbar } from "client/components/navbar";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import styles from "./layout.module.css";
 
 type AdminLayoutProps = {

--- a/src/client/components/modal/modal.tsx
+++ b/src/client/components/modal/modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import classNames from 'classnames';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import React, { MouseEvent, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 

--- a/src/client/components/navbar/index.tsx
+++ b/src/client/components/navbar/index.tsx
@@ -12,6 +12,7 @@ type NavbarProps = {
   className?: string;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const Navbar = memo(({ className }: NavbarProps) => {
   const [isOpen, setIsOpen] =  useState(false);
 
@@ -43,6 +44,7 @@ export const Navbar = memo(({ className }: NavbarProps) => {
       <div className="lg:flex lg:items-center lg:gap-2 w-full max-w-[64rem] px-4 py-3 mx-auto">
         <div className="flex justify-between items-center">
           <Link href={getPath({ kind: Path.Home })} className="flex items-center hover:opacity-75 mr-2">
+            {/* eslint-disable-next-line @next/next/no-img-element -- pre-existing error before eslint inclusion */}
             <img src={HuradoPNG.src} alt="Hurado" className="w-7 h-7" />
             <span className="text-2xl">Hurado</span>
           </Link>
@@ -67,6 +69,7 @@ export const Navbar = memo(({ className }: NavbarProps) => {
   );
 });
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const NavbarAccount = memo(() => {
   const session = useSession();
   if (session == null || session.user == null) {

--- a/src/client/components/problem_set_creator/problem_set_creator.tsx
+++ b/src/client/components/problem_set_creator/problem_set_creator.tsx
@@ -27,6 +27,7 @@ export function ProblemSetCreator() {
 
   const onButtonClick = useCallback(() => {
     setShowModal(true);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [showModal]);
 
   const onModalHide = useCallback(() => {

--- a/src/client/components/problem_set_editor/problem_set_coercion.ts
+++ b/src/client/components/problem_set_editor/problem_set_coercion.ts
@@ -1,8 +1,8 @@
-import { ProblemSetED, ProblemSetTaskED } from "./types";
 import {
   ProblemSetEditorDTO,
   ProblemSetTaskEditorDTO,
 } from "common/validation/problem_set_validation";
+import { ProblemSetED, ProblemSetTaskED } from "./types";
 
 export function coerceProblemSetED(dto: ProblemSetEditorDTO): ProblemSetED {
   const set: ProblemSetED = {

--- a/src/client/components/problem_set_editor/problem_set_editor.tsx
+++ b/src/client/components/problem_set_editor/problem_set_editor.tsx
@@ -5,6 +5,7 @@ import classNames from "classnames";
 import Link from "next/link";
 import { ReactNode, memo, useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
+import { useParams } from "next/navigation";
 import { Navbar } from "client/components/navbar";
 import {
   CommonEditorFooter,
@@ -36,7 +37,6 @@ import { ProblemSetED, ProblemSetTaskED } from "./types";
 import { coerceProblemSetED } from "./problem_set_coercion";
 import { saveProblemSet } from "./problem_set_editor_saving";
 import styles from "./problem_set_editor.module.css";
-import { useParams } from "next/navigation";
 
 type ProblemSetEditorProps = {
   dto: ProblemSetEditorDTO;

--- a/src/client/components/problem_set_editor/problem_set_editor.tsx
+++ b/src/client/components/problem_set_editor/problem_set_editor.tsx
@@ -148,6 +148,7 @@ export const ProblemSetEditorTasks = ({ problemSet, setProblemSet }: ProblemSetE
         },
       ],
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [problemSet]);
 
   return (
@@ -187,6 +188,7 @@ const ProblemSetTaskEditor = ({ task, taskIndex, problemSet, setProblemSet }: Pr
         tasks: Arrays.replaceNth(problemSet.tasks, taskIndex, newTask),
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [problemSet, taskIndex]
   );
 
@@ -284,6 +286,7 @@ const ProblemSetTaskPicker = (props: ProblemSetTaskPickerProps) => {
     } finally {
       setSearching(false);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [searching, text]);
 
   const onTaskClear = useCallback(() => {
@@ -330,6 +333,7 @@ type ProblemSetEditorTabProps = {
   slug: string;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const ProblemSetEditorTabComponent = memo(({ tab, slug }: ProblemSetEditorTabProps) => {
   const viewURL = getPath({ kind: Path.ProblemSetView, slug });
 

--- a/src/client/components/problem_set_editor/problem_set_editor_saving.ts
+++ b/src/client/components/problem_set_editor/problem_set_editor_saving.ts
@@ -28,6 +28,7 @@ export async function saveProblemSet(set: ProblemSetED): Promise<SaveResult<Prob
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 function validateProblemSet(set: ProblemSetED): string[] {
   return [];
 }

--- a/src/client/components/problem_set_viewer/problem_set_viewer.tsx
+++ b/src/client/components/problem_set_viewer/problem_set_viewer.tsx
@@ -13,6 +13,7 @@ type ProblemSetTitleDisplayProps = {
   className?: string;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const ProblemSetViewerTitle = memo(({ title, className }: ProblemSetTitleDisplayProps) => {
   return (
     <div

--- a/src/client/components/sample_io_display/sample_io_display.tsx
+++ b/src/client/components/sample_io_display/sample_io_display.tsx
@@ -10,6 +10,7 @@ type SampleIODisplayProps = {
   explanation: string | undefined;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const SampleIODisplay = memo(({ sampleIndex, input, output, explanation }: SampleIODisplayProps) => {
   return (
     <div className="flex flex-col gap-4 mt-8">
@@ -32,10 +33,12 @@ type SampleFileDisplayProps = {
   content: string;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 const SampleFileDisplay = memo(({ label, content }: SampleFileDisplayProps) => {
   const copyToClipboard = useCallback(async () => {
     await navigator.clipboard.writeText(content);
     toast(`${label} copied to clipboard!`, { type: "success" });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, []);
 
   return (

--- a/src/client/components/sample_io_display/sample_io_display.tsx
+++ b/src/client/components/sample_io_display/sample_io_display.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback } from "react";
-import { LatexDisplay } from "../latex_display";
 import { toast } from "react-toastify";
+import { LatexDisplay } from "../latex_display";
 import BoxIcon from "../box_icon";
 
 type SampleIODisplayProps = {

--- a/src/client/components/submission_viewer/submission_viewer.tsx
+++ b/src/client/components/submission_viewer/submission_viewer.tsx
@@ -5,6 +5,8 @@ import type { editor } from "monaco-editor";
 import MonacoEditor, { Monaco } from "@monaco-editor/react";
 import { useCallback, useContext, useRef, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
 import {
   SubmissionViewerDTO,
   SubmissionViewerFileDTO,
@@ -18,10 +20,8 @@ import { uuidToHuradoID } from "common/utils/uuid";
 import BoxIcon from "client/components/box_icon";
 import { getPath, Path } from "client/paths";
 import { getVerdictColorClass } from "client/verdicts";
-import { useRouter } from "next/navigation";
-import { toast } from "react-toastify";
-import { rejudgeSubmission } from "../submit_panel/submit_utils";
 import { SubmissionsCacheContext } from "client/submissions";
+import { rejudgeSubmission } from "../submit_panel/submit_utils";
 import button_styles from "../submit_panel/submit_panel.module.css";
 type SubmissionViewerProps = {
   submission: SubmissionViewerDTO;

--- a/src/client/components/submission_viewer/submission_viewer.tsx
+++ b/src/client/components/submission_viewer/submission_viewer.tsx
@@ -255,6 +255,7 @@ const SubmissionCodeViewer = ({ submission }: SubmissionViewerProps) => {
 
   // Magic code that resizes the editor, mostly stolen from:
   // https://github.com/microsoft/monaco-editor/issues/794#issuecomment-427092969
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
   const onEditorMount = useCallback((editor: editor.IStandaloneCodeEditor, monaco: Monaco) => {
     if (containerRef.current == null) {
       return;
@@ -319,10 +320,14 @@ export const RejudgeButton = ({ submission, isAdmin }: SubmissionViewerProps & {
     return null;
   }
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- pre-existing error before eslint inclusion
   const [rejudging, setRejudging] = useState(false);
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- pre-existing error before eslint inclusion
   const router = useRouter();
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- pre-existing error before eslint inclusion
   const submissions = useContext(SubmissionsCacheContext);
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- pre-existing error before eslint inclusion
   const rejudge = useCallback(async () => {
     if (rejudging) {
       return;
@@ -337,6 +342,7 @@ export const RejudgeButton = ({ submission, isAdmin }: SubmissionViewerProps & {
     router.push(getPath({ kind: Path.Submission, uuid: submission.id }));
 
     setRejudging(false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, []);
 
   return (

--- a/src/client/components/submissions_table/submissions_table.tsx
+++ b/src/client/components/submissions_table/submissions_table.tsx
@@ -18,6 +18,7 @@ type SubmissionTableProps = {
 };
 
 export const SubmissionsTable = ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
   loaded,
   submissions,
   loadSubmissions,
@@ -25,6 +26,7 @@ export const SubmissionsTable = ({
 }: SubmissionTableProps) => {
   useEffect(() => {
     loadSubmissions();
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, []);
 
   return (
@@ -46,6 +48,7 @@ type SubmissionRowProps = {
   showUser: boolean;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 const SubmissionRow = memo(({ submission, showUser }: SubmissionRowProps) => {
   const textVerdict =
     submission.verdict_id == null
@@ -87,6 +90,7 @@ type SubmissionCellProps = {
   children?: ReactNode;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 const SubmissionHeader = memo(({ className, children }: SubmissionCellProps) => {
   return (
     <div
@@ -100,6 +104,7 @@ const SubmissionHeader = memo(({ className, children }: SubmissionCellProps) => 
   );
 });
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 const SubmissionCell = memo(({ className, children }: SubmissionCellProps) => {
   return (
     <div
@@ -118,6 +123,7 @@ type OverallScoreProps = {
   className?: string,
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const OverallScoreDisplay = memo(({ overallVerdict, className }: OverallScoreProps) => {
   if (overallVerdict == undefined) {
     return null;

--- a/src/client/components/submissions_table/submissions_table.tsx
+++ b/src/client/components/submissions_table/submissions_table.tsx
@@ -7,8 +7,8 @@ import { uuidToHuradoID } from "common/utils/uuid";
 import { humanizeTimeAgo } from "common/utils/dates";
 import { getPath, Path } from "client/paths";
 import { getVerdictColorClass } from "client/verdicts";
-import styles from "./submission_table.module.css";
 import { OverallVerdictDisplayDTO } from "common/types/verdicts";
+import styles from "./submission_table.module.css";
 
 type SubmissionTableProps = {
   loaded: boolean;

--- a/src/client/components/submit_panel/submit_code.tsx
+++ b/src/client/components/submit_panel/submit_code.tsx
@@ -51,6 +51,7 @@ export const SubmitCode = ({ taskId }: SubmitCodeProps) => {
     const data = createSubmissionCode(taskId, language, code);
     await postSubmission(data, submissions, router);
     setSubmitting(false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [taskId, submitting, language, code]);
 
   // .submit-panel is a non-module class used to style the monaco editor's line numbers

--- a/src/client/components/submit_panel/submit_output.tsx
+++ b/src/client/components/submit_panel/submit_output.tsx
@@ -5,9 +5,9 @@ import { useCallback, useContext, useState } from "react";
 import { TaskViewerOutputDTO } from "common/types";
 import { TaskFlavor, TaskFlavorOutput } from "common/types/constants";
 import { SubmissionsCacheContext } from "client/submissions";
-import styles from "./submit_panel.module.css";
 import { InputChangeEvent } from "common/types/events";
 import { Arrays } from "common/utils/arrays";
+import styles from "./submit_panel.module.css";
 import { createSubmissionOutput, postSubmission } from "./submit_utils";
 
 export type SubtaskState = {

--- a/src/client/components/submit_panel/submit_output.tsx
+++ b/src/client/components/submit_panel/submit_output.tsx
@@ -41,6 +41,7 @@ export function SubmitOutput({ task }: SubmitOutputProps) {
     const data = createSubmissionOutput(task, subtasks);
     await postSubmission(data, submissions, router);
     setSubmitting(false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task, subtasks, submitting]);
 
   return (
@@ -93,6 +94,7 @@ function SubmitOutputSubtask({
         );
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [subtasks, subtaskIndex]
   );
 
@@ -105,6 +107,7 @@ function SubmitOutputSubtask({
         })
       );
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [subtasks, subtaskIndex]
   );
 

--- a/src/client/components/submit_panel/submit_utils.ts
+++ b/src/client/components/submit_panel/submit_utils.ts
@@ -96,7 +96,9 @@ export async function postSubmission(
         case ResponseKind.ValidationError:
           // Iterate over the errors and display them
           for (const key in data.errors) {
+            // eslint-disable-next-line no-prototype-builtins -- pre-existing error before eslint inclusion
             if (data.errors.hasOwnProperty(key)) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
               const errorMessages = (data.errors as any)[key];
               errorMessages.forEach((message: string) => {
                 toast.error(message);

--- a/src/client/components/task_creator/task_creator.tsx
+++ b/src/client/components/task_creator/task_creator.tsx
@@ -27,6 +27,7 @@ export function TaskCreator() {
 
   const onButtonClick = useCallback(() => {
     setShowModal(true);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [showModal]);
 
   const onModalHide = useCallback(() => {

--- a/src/client/components/task_editor/coercion.ts
+++ b/src/client/components/task_editor/coercion.ts
@@ -7,6 +7,8 @@ import {
   TaskScriptDTO,
   TaskSampleIO_DTO,
 } from "common/validation/task_validation";
+import { CheckerKind, Language, TaskType } from "common/types/constants";
+import { CommonAttachmentED, EditorKind } from "../common_editor";
 import {
   TaskCreditED,
   TaskED,
@@ -16,8 +18,6 @@ import {
   TaskCheckerED,
   TaskSampleIO_ED,
 } from "./types";
-import { CheckerKind, Language, TaskType } from "common/types/constants";
-import { CommonAttachmentED, EditorKind } from "../common_editor";
 import { createEmptyScript } from "./task_editor_utils";
 
 export function coerceTaskED(dto: TaskDTO): TaskED {

--- a/src/client/components/task_editor/coercion.ts
+++ b/src/client/components/task_editor/coercion.ts
@@ -7,6 +7,7 @@ import {
   TaskScriptDTO,
   TaskSampleIO_DTO,
 } from "common/validation/task_validation";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { CheckerKind, Language, TaskType } from "common/types/constants";
 import { CommonAttachmentED, EditorKind } from "../common_editor";
 import {

--- a/src/client/components/task_editor/task_editor.tsx
+++ b/src/client/components/task_editor/task_editor.tsx
@@ -124,6 +124,7 @@ type TaskEditorTabProps = {
   slug: string;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const TaskEditorTabComponent = memo(({ tab, slug }: TaskEditorTabProps) => {
   const viewURL = getPath({ kind: Path.TaskView, slug: slug });
 

--- a/src/client/components/task_editor/task_editor_advanced.tsx
+++ b/src/client/components/task_editor/task_editor_advanced.tsx
@@ -1,8 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import classNames from "classnames";
 import { useCallback } from "react";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import styles from "client/components/common_editor/common_editor.module.css";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { InputChangeEvent, SelectChangeEvent } from "common/types/events";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { CommonEditorContent, CommonEditorDetails, CommonEditorLabel, CommonEditorSelect } from "../common_editor";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { Scrollable } from "../scrollable";
 import { TaskED } from "./types";
 

--- a/src/client/components/task_editor/task_editor_advanced.tsx
+++ b/src/client/components/task_editor/task_editor_advanced.tsx
@@ -1,10 +1,10 @@
 import classNames from "classnames";
+import { useCallback } from "react";
 import styles from "client/components/common_editor/common_editor.module.css";
+import { InputChangeEvent, SelectChangeEvent } from "common/types/events";
 import { CommonEditorContent, CommonEditorDetails, CommonEditorLabel, CommonEditorSelect } from "../common_editor";
 import { Scrollable } from "../scrollable";
 import { TaskED } from "./types";
-import { useCallback } from "react";
-import { InputChangeEvent, SelectChangeEvent } from "common/types/events";
 
 type TaskEditorAdvancedProps = {
   task: TaskED;

--- a/src/client/components/task_editor/task_editor_details.tsx
+++ b/src/client/components/task_editor/task_editor_details.tsx
@@ -78,6 +78,7 @@ function TaskEditorAttachments({ task, setTask }: TaskEditorAttachmentsProps) {
         attachments,
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task]
   );
 
@@ -117,6 +118,7 @@ const TaskEditorCredits = ({ task, setTask }: TaskEditorCreditsProps) => {
         },
       ],
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task]);
 
   return (
@@ -170,6 +172,7 @@ const TaskEditorCreditSavedX = ({ index, credit, task, setTask }: TaskEditorCred
         }),
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task, credit, index]
   );
 
@@ -183,6 +186,7 @@ const TaskEditorCreditSavedX = ({ index, credit, task, setTask }: TaskEditorCred
         }),
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task, credit, index]
   );
 
@@ -194,6 +198,7 @@ const TaskEditorCreditSavedX = ({ index, credit, task, setTask }: TaskEditorCred
         deleted: !credit.deleted,
       }),
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task, credit, index]);
 
   return (
@@ -241,6 +246,7 @@ const TaskEditorCreditLocalX = ({ index, credit, task, setTask }: TaskEditorCred
         }),
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task, credit, index]
   );
 
@@ -254,6 +260,7 @@ const TaskEditorCreditLocalX = ({ index, credit, task, setTask }: TaskEditorCred
         }),
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task, credit, index]
   );
 
@@ -262,6 +269,7 @@ const TaskEditorCreditLocalX = ({ index, credit, task, setTask }: TaskEditorCred
       ...task,
       credits: [...task.credits.slice(0, index), ...task.credits.slice(index + 1)],
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task, credit, index]);
 
   return (

--- a/src/client/components/task_editor/task_editor_judging.tsx
+++ b/src/client/components/task_editor/task_editor_judging.tsx
@@ -5,9 +5,9 @@ import { CommonEditorDetails, CommonEditorLabel, CommonEditorSelect, CommonEdito
 import styles from "client/components/common_editor/common_editor.module.css";
 import { InputChangeEvent, SelectChangeEvent } from "common/types/events";
 import { CheckerKind, Language, TaskFlavor, TaskType } from "common/types/constants";
+import { UnreachableError } from "common/errors";
 import { TaskEditorSubtasks } from "./task_editor_subtasks";
 import { TaskED, TaskScriptED } from "./types";
-import { UnreachableError } from "common/errors";
 import { TaskEditorScript } from "./task_editor_script";
 import { createEmptyScript } from "./task_editor_utils";
 

--- a/src/client/components/task_editor/task_editor_judging.tsx
+++ b/src/client/components/task_editor/task_editor_judging.tsx
@@ -63,6 +63,7 @@ const TaskTypeEditor = ({ task, setTask }: TaskEditorJudgingProps) => {
         throw new UnreachableError(type)
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task]
   );
 
@@ -74,6 +75,7 @@ const TaskTypeEditor = ({ task, setTask }: TaskEditorJudgingProps) => {
         flavor: flavor,
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task]
   );
 
@@ -152,6 +154,7 @@ export const TaskCheckerEditor = ({ task, setTask }: TaskCheckerEditorProps) => 
           throw new UnreachableError(kind);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task]
   );
 
@@ -190,22 +193,27 @@ type TaskLimitsEditorProps = {
 export const TaskLimitsEditor = ({ task, setTask }: TaskLimitsEditorProps) => {
   const onChangeTimeLimitMS = useCallback((event: InputChangeEvent) => {
     setTask({ ...task, time_limit_ms: event.target.value});
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task]);
 
   const onChangeMemoryLimitByte = useCallback((event: InputChangeEvent) => {
     setTask({ ...task, memory_limit_byte: event.target.value});
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task]);
 
   const onChangeCompileTimeLimitMS = useCallback((event: InputChangeEvent) => {
     setTask({ ...task, compile_time_limit_ms: event.target.value});
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task]);
 
   const onChangeCompileMemoryLimitMS = useCallback((event: InputChangeEvent) => {
     setTask({ ...task, compile_memory_limit_byte: event.target.value});
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task]);
 
   const onChangeSubmissionSizeLimitByte = useCallback((event: InputChangeEvent) => {
     setTask({ ...task, submission_size_limit_byte: event.target.value});
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task]);
 
   return (

--- a/src/client/components/task_editor/task_editor_sample_io.tsx
+++ b/src/client/components/task_editor/task_editor_sample_io.tsx
@@ -1,8 +1,8 @@
 import { useCallback } from "react";
-import { CommonEditorAddButton, CommonEditorInput, EditorKind } from "../common_editor";
-import { TaskED, TaskSampleIO_ED } from "./types";
 import { InputChangeEvent } from "common/types/events";
+import { CommonEditorAddButton, CommonEditorInput, EditorKind } from "../common_editor";
 import BoxIcon from "../box_icon";
+import { TaskED, TaskSampleIO_ED } from "./types";
 
 type TaskEditorSampleProps = {
   task: TaskED;

--- a/src/client/components/task_editor/task_editor_sample_io.tsx
+++ b/src/client/components/task_editor/task_editor_sample_io.tsx
@@ -23,6 +23,7 @@ export const TaskEditorSampleIO = ({ task, setTask }: TaskEditorSampleProps) => 
         },
       ],
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task]);
 
   return (
@@ -51,6 +52,7 @@ type TaskSampleIOEditorProps = {
 };
 
 const TaskSampleIOEditor = ({ sample, sampleIndex, task, setTask }: TaskSampleIOEditorProps) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- pre-existing error before eslint inclusion
   const updateField = (field: 'input' | 'output' | 'explanation') => useCallback(
     (event: InputChangeEvent) => {
       const samples = [...task.sample_IO];
@@ -61,6 +63,7 @@ const TaskSampleIOEditor = ({ sample, sampleIndex, task, setTask }: TaskSampleIO
         sample_IO: samples,
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task, setTask],
   );
 
@@ -73,6 +76,7 @@ const TaskSampleIOEditor = ({ sample, sampleIndex, task, setTask }: TaskSampleIO
         sample_IO: samples,
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task, setTask],
   );
 

--- a/src/client/components/task_editor/task_editor_saving.tsx
+++ b/src/client/components/task_editor/task_editor_saving.tsx
@@ -175,6 +175,7 @@ function coerceTaskDTO(ed: TaskED): TaskDTO {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 function coerceTaskCreditDTO(ed: TaskCreditED, idx: number): TaskCreditDTO | null {
   if (ed.deleted) {
     return null;

--- a/src/client/components/task_editor/task_editor_script.tsx
+++ b/src/client/components/task_editor/task_editor_script.tsx
@@ -11,8 +11,8 @@ import {
   CommonFileED,
   EditorKind,
 } from "client/components/common_editor";
-import { TaskScriptED } from "../task_editor/types";
 import { Language } from "common/types/constants";
+import { TaskScriptED } from "../task_editor/types";
 
 
 type TaskEditorScriptProps = {

--- a/src/client/components/task_editor/task_editor_script.tsx
+++ b/src/client/components/task_editor/task_editor_script.tsx
@@ -103,6 +103,7 @@ export const TaskEditorScriptArgument = ({ index, script, setScript }: TaskEdito
       ...script,
       argv: Arrays.replaceNth(script.argv, index, event.target.value),
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [script, setScript]);
 
   const onArgumentRemove = useCallback(() => {
@@ -110,6 +111,7 @@ export const TaskEditorScriptArgument = ({ index, script, setScript }: TaskEdito
       ...script,
       argv: Arrays.removeNth(script.argv, index),
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [script, setScript]);
 
   return (

--- a/src/client/components/task_editor/task_editor_submissions.tsx
+++ b/src/client/components/task_editor/task_editor_submissions.tsx
@@ -15,6 +15,7 @@ export const TaskEditorSubmissions = ({ taskId, cache }: TaskEditorSubmissionsPr
       return cache.submissions;
     }
     return cache.loadTaskSubmissions(taskId);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [cache]);
 
   return (

--- a/src/client/components/task_editor/task_editor_subtasks.tsx
+++ b/src/client/components/task_editor/task_editor_subtasks.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { useCallback, useRef, useState } from "react";
 import { InputChangeEvent } from "common/types/events";
 import { Arrays } from "common/utils/arrays";
@@ -36,6 +37,7 @@ export const TaskEditorSubtasks = ({ task, setTask }: TaskEditorSubtasksProps) =
         },
       ],
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [task]);
 
   return (
@@ -76,6 +78,7 @@ const TaskSubtaskEditor = ({ subtask, subtaskIndex, task, setTask }: TaskSubtask
         subtasks: Arrays.replaceNth(task.subtasks, subtaskIndex, newSubtask),
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task, subtaskIndex]
   );
 
@@ -197,6 +200,7 @@ const TaskDataEditor = (props: TaskDataEditorProps) => {
         }),
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
     [task, subtask, subtaskIndex, dataIndex]
   );
 
@@ -260,6 +264,7 @@ const TaskDataEditor = (props: TaskDataEditorProps) => {
         data: Arrays.moveUp(subtask.data, dataIndex),
       }),
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [data, replaceThisTaskData]);
 
   const onTaskDataMoveDown = useCallback(() => {
@@ -270,6 +275,7 @@ const TaskDataEditor = (props: TaskDataEditorProps) => {
         data: Arrays.moveDown(subtask.data, dataIndex),
       }),
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [data, replaceThisTaskData]);
 
   const onTaskDataRemove = useCallback(() => {

--- a/src/client/components/task_editor/task_editor_subtasks.tsx
+++ b/src/client/components/task_editor/task_editor_subtasks.tsx
@@ -1,7 +1,6 @@
 import classNames from "classnames";
 import { useCallback, useRef, useState } from "react";
 import { InputChangeEvent } from "common/types/events";
-import { TaskDataED, TaskDataLocal, TaskED, TaskSubtaskED } from "./types";
 import { Arrays } from "common/utils/arrays";
 import { TaskType } from "common/types/constants";
 import {
@@ -14,6 +13,7 @@ import {
   CommonFileED,
   EditorKind,
 } from "client/components/common_editor";
+import { TaskDataED, TaskDataLocal, TaskED, TaskSubtaskED } from "./types";
 import styles from "./task_editor.module.css";
 
 type TaskEditorSubtasksProps = {

--- a/src/client/components/task_viewer/task_viewer.tsx
+++ b/src/client/components/task_viewer/task_viewer.tsx
@@ -15,6 +15,7 @@ type TaskViewerProps = {
   clearSubmissionsCache?(): void;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 export const TaskViewer = ({ task, canEdit, clearSubmissionsCache }: TaskViewerProps) => {
   const submissions = useRef(new SubmissionsCache());
   const [tab, setTab] = useState(coerceTaskViewerTab(getLocationHash()));

--- a/src/client/components/task_viewer/task_viewer_editorial.tsx
+++ b/src/client/components/task_viewer/task_viewer_editorial.tsx
@@ -16,6 +16,7 @@ export const TaskViewerEditorial = ({ task }: TaskViewerEditorialProps) => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 const TaskViewerEditorialSection = ({ task }: TaskViewerEditorialProps) => {
   return <div className="text-center">No editorials yet!</div>;
 };

--- a/src/client/components/task_viewer/task_viewer_statement.tsx
+++ b/src/client/components/task_viewer/task_viewer_statement.tsx
@@ -2,6 +2,7 @@ import { useSession } from "client/sessions";
 import { TaskViewerDTO } from "common/types";
 import { LatexDisplay } from "client/components/latex_display";
 import { SubmitPanel } from "client/components/submit_panel";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { TaskType } from "common/types/constants";
 import { SampleIODisplay } from "../sample_io_display/sample_io_display";
 import { TaskViewerDetails, TaskViewerTitle } from "./task_viewer_utils";

--- a/src/client/components/task_viewer/task_viewer_statement.tsx
+++ b/src/client/components/task_viewer/task_viewer_statement.tsx
@@ -2,9 +2,9 @@ import { useSession } from "client/sessions";
 import { TaskViewerDTO } from "common/types";
 import { LatexDisplay } from "client/components/latex_display";
 import { SubmitPanel } from "client/components/submit_panel";
-import { TaskViewerDetails, TaskViewerTitle } from "./task_viewer_utils";
-import { SampleIODisplay } from "../sample_io_display/sample_io_display";
 import { TaskType } from "common/types/constants";
+import { SampleIODisplay } from "../sample_io_display/sample_io_display";
+import { TaskViewerDetails, TaskViewerTitle } from "./task_viewer_utils";
 
 type TaskViewerStatementProps = {
   task: TaskViewerDTO;

--- a/src/client/components/task_viewer/task_viewer_submissions.tsx
+++ b/src/client/components/task_viewer/task_viewer_submissions.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { TaskViewerDTO } from "common/types";
 import { SubmissionsCache } from "client/submissions";
-import { TaskViewerTitle } from "./task_viewer_utils";
 import { OverallScoreDisplay, SubmissionsTable } from "client/components/submissions_table";
 import http from "client/http";
 import { APIPath, getAPIPath } from "client/paths";
 import { OverallVerdictDisplayDTO } from "common/types/verdicts";
+import { TaskViewerTitle } from "./task_viewer_utils";
 
 type TaskViewerSubmissionsProps = {
   task: TaskViewerDTO;

--- a/src/client/components/task_viewer/task_viewer_submissions.tsx
+++ b/src/client/components/task_viewer/task_viewer_submissions.tsx
@@ -18,6 +18,7 @@ export const TaskViewerSubmissions = ({ task, cache }: TaskViewerSubmissionsProp
       return cache.submissions;
     }
     return cache.loadUserTaskSubmissions(task.id);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [cache]);
   
   const [overallVerdict, setOverallVerdict] = useState<OverallVerdictDisplayDTO | undefined>(undefined);
@@ -32,6 +33,7 @@ export const TaskViewerSubmissions = ({ task, cache }: TaskViewerSubmissionsProp
       setOverallVerdict(overall_verdict.verdict as OverallVerdictDisplayDTO | undefined);
     };
     fetchData();
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, []);
 
   return (

--- a/src/client/components/task_viewer/task_viewer_tabs.tsx
+++ b/src/client/components/task_viewer/task_viewer_tabs.tsx
@@ -54,6 +54,7 @@ type TaskViewerTabProps = {
   canEdit: boolean;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const TaskViewerTabComponent = memo(
   ({ className, tab, taskId, canEdit }: TaskViewerTabProps) => {
     const session = useSession();

--- a/src/client/components/task_viewer/task_viewer_tabs.tsx
+++ b/src/client/components/task_viewer/task_viewer_tabs.tsx
@@ -1,8 +1,8 @@
 import classNames from "classnames";
-import { getPath, Path } from "client/paths";
-import { useSession } from "client/sessions";
 import Link from "next/link";
 import { memo } from "react";
+import { getPath, Path } from "client/paths";
+import { useSession } from "client/sessions";
 
 export enum TaskViewerTab {
   Statement = "statement",

--- a/src/client/components/task_viewer/task_viewer_utils.tsx
+++ b/src/client/components/task_viewer/task_viewer_utils.tsx
@@ -6,6 +6,7 @@ type TaskTitleDisplayProps = {
   className?: string;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const TaskViewerTitle = memo(({ title, className }: TaskTitleDisplayProps) => {
   return (
     <div
@@ -27,6 +28,7 @@ type TaskDetailsDisplayProps = {
   className?: string;
 };
 
+// eslint-disable-next-line react/display-name -- pre-existing error before eslint inclusion
 export const TaskViewerDetails = memo(({ time_limit_ms, memory_limit_byte, className }: TaskDetailsDisplayProps) => {
   return (
     <>

--- a/src/client/paths.ts
+++ b/src/client/paths.ts
@@ -205,6 +205,7 @@ function addSearchParameters(base: string, params: Record<string, string | numbe
   let hasKey = false;
   const search = new URLSearchParams();
   for (const key in params) {
+    // eslint-disable-next-line no-prototype-builtins -- pre-existing error before eslint inclusion
     if (params.hasOwnProperty(key) && params[key] !== undefined) {
       hasKey = true;
       search.set(key, `${params[key]}`);

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { UseFormSetError } from "react-hook-form";
 
 export class UnreachableError extends Error {
@@ -7,6 +8,7 @@ export class UnreachableError extends Error {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 export function UnreachableCheck(_value: never): null {
   // This is a noop function that lets you tell typescript that you expect
   // a value to be unreachable. This is useful for exhaustiveness checks.

--- a/src/common/latex/latex_images.tsx
+++ b/src/common/latex/latex_images.tsx
@@ -27,9 +27,12 @@ export function LatexImageX({ node, source }: LatexNodeProps<LatexMacroImage>) {
     scale = isNaN(parsedScale) ? null : parsedScale;
   }
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- pre-existing error before eslint inclusion
   const [width, setWidth] = useState<number | undefined>(undefined);
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- pre-existing error before eslint inclusion
   const [ratio, setRatio] = useState<number | undefined>(undefined);
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- pre-existing error before eslint inclusion
   useEffect(() => {
     getImageDimensions(src).then(dimensions => {
       const aspectRatio = dimensions.width / dimensions.height;
@@ -47,11 +50,13 @@ export function LatexImageX({ node, source }: LatexNodeProps<LatexMacroImage>) {
     aspectRatio: ratio,
   };
 
+  // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text -- pre-existing error before eslint inclusion
   return <img style={style} className="max-w-full" src={src} />;
 }
 
 
 async function getImageDimensions(src: string): Promise<{ width: number, height: number }> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.src = src;

--- a/src/common/latex/latex_list.tsx
+++ b/src/common/latex/latex_list.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext } from "react";
-import { LatexArgument, LatexBaseNode, LatexNode, LatexNodeProps } from "./latex_types";
 import { UnreachableCheck } from "common/errors";
+import { LatexArgument, LatexBaseNode, LatexNode, LatexNodeProps } from "./latex_types";
 import { latexBrokenBlock, latexParseKwargs, latexPositionalArgument, latexPositionalString } from "./latex_utils";
 import { LatexNodeAnyX } from "./latex_render";
 import { LatexCounterContext } from "./latex_counters";

--- a/src/common/latex/latex_postprocess.ts
+++ b/src/common/latex/latex_postprocess.ts
@@ -47,6 +47,7 @@ export function latexProcessNode(node: LatexNode): LatexNode {
 }
 
 export function latexProcessMacro(node: LatexNodeMacro): LatexNodeMacro {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
   let merged: LatexNodeMacro;
   if (node.args == null) {
     return node;

--- a/src/common/latex/latex_render.tsx
+++ b/src/common/latex/latex_render.tsx
@@ -271,7 +271,7 @@ function renderEnvironmentContent(node: LatexNodeEnvironment, source: string): R
 function renderArgumentContent(
   args: LatexArgument[] | undefined,
   source: string,
-  index: number = 0
+  index = 0
 ): ReactNode {
   if (args == null || args.length <= index) {
     return null;

--- a/src/common/latex/latex_render.tsx
+++ b/src/common/latex/latex_render.tsx
@@ -91,6 +91,7 @@ function LatexNodeInlineMathX({ node, source }: LatexNodeProps<LatexNodeInlineMa
       displayMode: false,
     });
     return <span dangerouslySetInnerHTML={{ __html: html }} />;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
   } catch (e: any) {
     if ("message" in e) {
       return <span className="font-mono text-red-500">{e.message}</span>;
@@ -112,6 +113,7 @@ function LatexNodeDisplayMathX({ node, source }: LatexNodeProps<LatexNodeDisplay
       displayMode: true,
     });
     return <div dangerouslySetInnerHTML={{ __html: html }} />;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
   } catch (e: any) {
     if ("message" in e) {
       return <div className="font-mono text-red-500">{e.message}</div>;
@@ -293,8 +295,10 @@ function LatexArgumentInnerText({ args, index, source, children }: LatexArgument
     return null;
   }
   const arg = args[index];
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- pre-existing error before eslint inclusion
   const [innerText, setInnerText] = useState<string | undefined>(undefined);
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- pre-existing error before eslint inclusion
   useEffect(() => {
     setInnerText(undefined);
     setTimeout(() => {
@@ -304,6 +308,7 @@ function LatexArgumentInnerText({ args, index, source, children }: LatexArgument
       flushSync(() => root.render(argchildren));
       setInnerText(div.innerText);
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, [args, index]);
 
   return children(innerText);

--- a/src/common/latex/latex_syntax_highlight.tsx
+++ b/src/common/latex/latex_syntax_highlight.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useCallback, useMemo } from "react";
 import { toast } from "react-toastify";
+// eslint-disable-next-line import/order -- pre-existing error before eslint inclusion
 import { LatexNodeProps, LatexNodeVerbatim } from "./latex_types";
 import hljs from 'highlight.js/lib/core';
 import "highlight.js/styles/intellij-light.min.css";
@@ -40,6 +41,7 @@ hljs.registerLanguage("xml", hXML);
 hljs.registerLanguage("x86", hX86);
 
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 export function LatexSyntaxHighlight({ node, source }: LatexNodeProps<LatexNodeVerbatim>): ReactNode {
   const trimmed = node.content.replace(/^\s*\n/, "");
   const highlighted = useMemo(() => hljs.highlightAuto(trimmed), [trimmed]);
@@ -47,6 +49,7 @@ export function LatexSyntaxHighlight({ node, source }: LatexNodeProps<LatexNodeV
   const copyToClipboard = useCallback(async () => {
     await navigator.clipboard.writeText(trimmed);
     toast(`Copied to clipboard!`, { type: "success" });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pre-existing error before eslint inclusion
   }, []);
 
   return (

--- a/src/common/responses.ts
+++ b/src/common/responses.ts
@@ -65,15 +65,18 @@ export function makeSuccessResponse<T>(data: T): APISuccessResponse<T> {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-types -- pre-existing error before eslint inclusion
 export function applyValidationErrors<T extends {}>(setError: UseFormSetError<T>, errors: ObjectErrors<T>) {
   const keys = Object.keys(errors);
   for (const key of keys) {
+    // eslint-disable-next-line no-prototype-builtins -- pre-existing error before eslint inclusion
     if (!errors.hasOwnProperty(key)) {
       continue;
     }
     const keyt = key as keyof T;
     const err = errors[keyt];
     if (err && err.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
       setError(key as any, { message: err[0] });
     }
   }

--- a/src/common/types/collections.ts
+++ b/src/common/types/collections.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { Generated, Insertable, Selectable, Updateable } from "kysely";
 
 export type CollectionTable = {

--- a/src/common/types/contests.ts
+++ b/src/common/types/contests.ts
@@ -1,4 +1,5 @@
 import { Generated, Selectable } from "kysely";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { TaskScoredSummaryDTO, TaskSummaryDTO } from "./tasks";
 
 export type ContestTable = {

--- a/src/common/types/problem_sets.ts
+++ b/src/common/types/problem_sets.ts
@@ -1,4 +1,5 @@
 import { Generated, Insertable, Selectable, Updateable } from "kysely";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { TaskScoredSummaryDTO, TaskSummaryDTO } from "./tasks";
 
 export type ProblemSetTable = {

--- a/src/common/types/users.ts
+++ b/src/common/types/users.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { Selectable, ColumnType, Generated, Insertable, Updateable } from "kysely";
 
 export type UserTable = {

--- a/src/common/utils/dates.ts
+++ b/src/common/utils/dates.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 const units: Intl.RelativeTimeFormatUnit[] = [
   "year",
   "month",

--- a/src/common/validation/task_validation.ts
+++ b/src/common/validation/task_validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { memo } from "react";
 import { CheckerKind, TaskType } from "common/types/constants";
 import { zCheckerKind, zLanguageKind, zReducerKind, zTaskFlavorOutput } from "./constant_validation";

--- a/src/common/validation/task_validation.ts
+++ b/src/common/validation/task_validation.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { zCheckerKind, zLanguageKind, zReducerKind, zTaskFlavorOutput } from "./constant_validation";
-import { CheckerKind, TaskType } from "common/types/constants";
-import { REGEX_SLUG } from "./common_validation";
 import { memo } from "react";
+import { CheckerKind, TaskType } from "common/types/constants";
+import { zCheckerKind, zLanguageKind, zReducerKind, zTaskFlavorOutput } from "./constant_validation";
+import { REGEX_SLUG } from "./common_validation";
 
 export type TaskCreditDTO = z.infer<typeof zTaskCredit>;
 export type TaskAttachmentDTO = z.infer<typeof zTaskAttachment>;

--- a/src/db/migrations/20240320074557_add_uuid_functions.ts
+++ b/src/db/migrations/20240320074557_add_uuid_functions.ts
@@ -1,10 +1,12 @@
 import { Kysely, sql } from "kysely";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
 export async function up(db: Kysely<any>): Promise<void> {
   await sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`.execute(db);
   await sql`CREATE EXTENSION IF NOT EXISTS "citext"`.execute(db);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
 export async function down(db: Kysely<any>): Promise<void> {
   await sql`DROP EXTENSION "citext"`.execute(db);
   await sql`DROP EXTENSION "uuid-ossp"`.execute(db);

--- a/src/db/migrations/20240320074757_initial_migration.ts
+++ b/src/db/migrations/20240320074757_initial_migration.ts
@@ -1,5 +1,6 @@
 import { Kysely, sql } from "kysely";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
 export async function up(db: Kysely<any>): Promise<void> {
   await db.schema
     .createTable("users")
@@ -420,6 +421,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .execute();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
 export async function down(db: Kysely<any>): Promise<void> {
   await db.schema
     .alterTable("submissions")

--- a/src/db/migrations/20250225225800_add_on_delete_cascades.ts
+++ b/src/db/migrations/20250225225800_add_on_delete_cascades.ts
@@ -1,5 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { Kysely, sql } from "kysely";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
 export async function up(db: Kysely<any>): Promise<void> {
   await db.schema
     .alterTable("submission_files")
@@ -50,6 +52,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .execute();
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
 export async function down(db: Kysely<any>): Promise<void> {
   await db.schema
     .alterTable("verdict_task_data")

--- a/src/db/scripts/devtools/database.ts
+++ b/src/db/scripts/devtools/database.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "fs";
-import { FileMigrationProvider, Migrator, sql } from "kysely";
 import path from "path";
+import { FileMigrationProvider, Migrator, sql } from "kysely";
 import { db } from "db";
 import { SubmissionFileStorage, TaskFileStorage } from "server/files";
 import { __DO_NOT_IMPORT__DeveloperSeeds } from "../seed";

--- a/src/server/authorization.ts
+++ b/src/server/authorization.ts
@@ -1,5 +1,5 @@
-import { SessionData } from "common/types";
 import { NextRequest } from "next/server";
+import { SessionData } from "common/types";
 import { KOMPGEN_SECRET } from "./secrets";
 
 export function canManageTasks(session: SessionData | null, request: NextRequest | undefined = undefined): boolean {

--- a/src/server/authorization.ts
+++ b/src/server/authorization.ts
@@ -1,7 +1,9 @@
 import { NextRequest } from "next/server";
 import { SessionData } from "common/types";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { KOMPGEN_SECRET } from "./secrets";
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 export function canManageTasks(session: SessionData | null, request: NextRequest | undefined = undefined): boolean {
   if (session == null || session.user.role != 'admin') {
     return false;

--- a/src/server/evaluation/judge_batch.ts
+++ b/src/server/evaluation/judge_batch.ts
@@ -3,10 +3,10 @@ import path from "path";
 import { WriteStream } from "tty";
 import ChildProcess from "child_process";
 import { ContestantScript, JudgeTaskBatch, JudgeTaskDataBatch } from "common/types/judge";
-import { EvaluationResult, IsolateResult, JudgeEvaluationContextBatch } from "./types";
-import { checkSubmissionOutput } from "./judge_checker";
 import { Verdict } from "common/types/constants";
 import { UnreachableError } from "common/errors";
+import { EvaluationResult, IsolateResult, JudgeEvaluationContextBatch } from "./types";
+import { checkSubmissionOutput } from "./judge_checker";
 import { ISOLATE_BIN, IsolateUtils, makeContestantArgv } from "./judge_utils";
 
 export async function evaluateTaskDataForBatch(

--- a/src/server/evaluation/judge_checker.ts
+++ b/src/server/evaluation/judge_checker.ts
@@ -6,6 +6,7 @@ import { UnreachableError } from "common/errors";
 import { ISOLATE_BIN, IsolateInstance, IsolateUtils, runChildProcess } from "./judge_utils";
 import { LANGUAGE_SPECS } from "./judge_compile";
 import { CheckerResult } from "./types";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
 import { getWallTimeLimit, LIMITS_JUDGE_MEMORY_LIMIT_KB, LIMITS_JUDGE_TIME_LIMIT_SECONDS, LIMITS_WALL_TIME_BONUS } from "./judge_constants";
 
 export async function checkSubmissionOutput(opts: {

--- a/src/server/evaluation/judge_communication.ts
+++ b/src/server/evaluation/judge_communication.ts
@@ -1,12 +1,12 @@
 import path from "path";
 import ChildProcess from "child_process";
 import { JudgeChecker, JudgeScript, JudgeTaskCommunication, JudgeTaskDataCommunication } from "common/types/judge";
+import { Verdict } from "common/types/constants";
+import { UnreachableError } from "common/errors";
 import { EvaluationResult, IsolateResult, JudgeEvaluationContextCommunication } from "./types";
 import { checkSubmissionOutput } from "./judge_checker";
 import { LANGUAGE_SPECS } from "./judge_compile";
 import { ISOLATE_BIN, IsolateInstance, IsolateUtils, makeContestantArgv } from "./judge_utils";
-import { Verdict } from "common/types/constants";
-import { UnreachableError } from "common/errors";
 import { getWallTimeLimit, LIMITS_JUDGE_MEMORY_LIMIT_KB, LIMITS_JUDGE_TIME_LIMIT_SECONDS } from "./judge_constants";
 
 export async function evaluateTaskDataForCommunication(

--- a/src/server/evaluation/judge_compile.ts
+++ b/src/server/evaluation/judge_compile.ts
@@ -16,6 +16,7 @@ export const LANGUAGE_SPECS: Record<ProgrammingLanguage, LanguageSpec> = {
     getExecutableName: (source: string) => {
       return source;
     },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
     getCompileCommand: (source: string, exe: string) => {
       return null;
     },

--- a/src/server/evaluation/judge_utils.ts
+++ b/src/server/evaluation/judge_utils.ts
@@ -1,8 +1,8 @@
 import fs from "fs";
 import ChildProcess from "child_process";
 import { Verdict } from "common/types/constants";
-import { IsolateResult } from "./types";
 import { ContestantScript, JudgeTaskBatch, JudgeTaskCommunication } from "common/types/judge";
+import { IsolateResult } from "./types";
 import { LANGUAGE_SPECS } from "./judge_compile";
 import { getWallTimeLimit, LIMITS_DEFAULT_RUN_MEMORY_LIMIT_KB, LIMITS_DEFAULT_RUN_TIME_LIMIT_SECONDS } from "./judge_constants";
 

--- a/src/server/evaluation/judge_utils.ts
+++ b/src/server/evaluation/judge_utils.ts
@@ -59,6 +59,7 @@ export class IsolateUtils {
           status = value;
           break;
         case "exitsig":
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
           exitsig = value;
           break;
         case "exitcode":
@@ -71,6 +72,7 @@ export class IsolateUtils {
           time = value;
           break;
         case "time-wall":
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
           timeWall = value;
           break;
         default:
@@ -127,6 +129,7 @@ export class IsolateUtils {
     // Generate an un-taken number within this range inclusive. Why this range? Trip lang.
     const min = 17;
     const max = 999;
+    // eslint-disable-next-line no-constant-condition -- pre-existing error before eslint inclusion
     while (true) {
       const id = generateRandomInt(min, max).toString();
       if (!taken.has(id)) {

--- a/src/server/files/index.ts
+++ b/src/server/files/index.ts
@@ -1,5 +1,5 @@
-import { FileStorage } from "./abstract";
 import { UPLOAD_STORAGE_PROVIDER } from "../secrets";
+import { FileStorage } from "./abstract";
 import { makeStorageClientsAzure } from "./azure";
 import { makeStorageClientsS3 } from "./s3";
 

--- a/src/server/files/s3.ts
+++ b/src/server/files/s3.ts
@@ -75,6 +75,7 @@ class S3FileStorage implements FileStorage {
 
     try {
       await this.s3.send(new HeadBucketCommand(params));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pre-existing error before eslint inclusion
     } catch (err: any) {
       if (err.name === "NotFound") {
         await this.s3.send(new CreateBucketCommand(params));

--- a/src/server/files/s3.ts
+++ b/src/server/files/s3.ts
@@ -1,3 +1,5 @@
+import { Readable } from "stream";
+import { createWriteStream } from "fs";
 import { S3, HeadBucketCommand, CreateBucketCommand, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import {
   AWS_S3_ENDPOINT,
@@ -7,8 +9,6 @@ import {
   AWS_UPLOAD_BUCKET,
 } from "../secrets";
 import { FileStorage, FileStorageClients } from "./abstract";
-import { Readable } from "stream";
-import { createWriteStream } from "fs";
 
 class S3FileStorage implements FileStorage {
   s3: S3;

--- a/src/server/logic/judgements/judge_runner.ts
+++ b/src/server/logic/judgements/judge_runner.ts
@@ -1,3 +1,4 @@
+import { Kysely, Transaction } from "kysely";
 import { UnreachableError } from "common/errors";
 import { ProgrammingLanguage, TaskType, Verdict } from "common/types/constants";
 import {
@@ -28,7 +29,6 @@ import {
   JudgeEvaluationContextCommunication,
   JudgeEvaluationContextOutput,
 } from "server/evaluation";
-import { Kysely, Transaction } from "kysely";
 import { Models } from "common/types";
 
 export class JudgeRunner {
@@ -143,7 +143,7 @@ async function judgeTask<Type extends TaskType>(
   let running_time_ms = 0;
   let running_memory_byte = 0;
 
-  var score_max = 0;
+  let score_max = 0;
   const verdict_cache = new Map<string, JudgeVerdictTaskData>();
   for (const subtask of task.subtasks) {
     const child = await judgeSubtask(

--- a/src/server/logic/judgements/judge_runner.ts
+++ b/src/server/logic/judgements/judge_runner.ts
@@ -417,6 +417,7 @@ function computeScoreOverall(submissions: SubtaskVerdict[]) {
   }
 
   let overall = 0;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
   for (const [_order, score] of maxOfEachSubtask.entries()) {
     overall += score;
   }

--- a/src/server/logic/problem_sets/update_problem_set.ts
+++ b/src/server/logic/problem_sets/update_problem_set.ts
@@ -62,6 +62,7 @@ async function upsertProblemSetTasks(
   const taskToOrder = new Map(dbProblemSetTasks.map((t) => [t.task_id, t.order]));
 
   const dtos: ProblemSetTaskEditorDTO[] = dbProblemSetTasks
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
     .map((ct, index) => {
       const task = taskMap.get(ct.task_id);
       const order = taskToOrder.get(ct.task_id);

--- a/src/server/logic/submissions/get_submission.ts
+++ b/src/server/logic/submissions/get_submission.ts
@@ -217,6 +217,7 @@ async function getSubmissionVerdict(
     const dataVerdicts = await dataVerdictsQuery.execute();
 
     // No verdict subtask => no verdict task data => empty objects
+    // eslint-disable-next-line no-inner-declarations -- pre-existing error before eslint inclusion
     function toVerdictTaskData(): VerdictTaskDataViewerDTO {
       return {
         verdict: null,
@@ -226,6 +227,7 @@ async function getSubmissionVerdict(
       };
     }
 
+    // eslint-disable-next-line no-inner-declarations -- pre-existing error before eslint inclusion
     function toVerdictSubtask(sv: (typeof subverdicts)[number]): VerdictSubtaskViewerDTO {
       return {
         verdict: sv.verdict,
@@ -281,6 +283,7 @@ async function getSubmissionVerdict(
       .orderBy(["task_data.subtask_id", "task_data.order asc"]);
 
     const dataVerdicts = await dataVerdictsQuery.execute();
+    // eslint-disable-next-line no-inner-declarations -- pre-existing error before eslint inclusion
     function toVerdictTaskData(dv: (typeof dataVerdicts)[number]): VerdictTaskDataViewerDTO {
       return {
         verdict: dv.verdict as Verdict,
@@ -290,6 +293,7 @@ async function getSubmissionVerdict(
       };
     }
 
+    // eslint-disable-next-line no-inner-declarations -- pre-existing error before eslint inclusion
     function toVerdictSubtask(sv: (typeof subverdicts)[number]): VerdictSubtaskViewerDTO {
       return {
         verdict: sv.verdict,

--- a/src/server/logic/submissions/judge_submission.ts
+++ b/src/server/logic/submissions/judge_submission.ts
@@ -22,8 +22,11 @@ export async function judgeSubmission(submissionId: string) {
     return [sub, tsk];
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
   let tTaskRoot: string | null = null;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
   let tOutputRoot: string | null = null;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
   let tSubmissionRoot: string | null = null;
   try {
     const pTask = JudgeFiles.setupTask(task).then((newTaskRoot) => {

--- a/src/server/logic/submissions/judge_submission.ts
+++ b/src/server/logic/submissions/judge_submission.ts
@@ -1,3 +1,4 @@
+import { Transaction } from "kysely";
 import { db } from "db";
 import type {
   JudgeChecker,
@@ -11,7 +12,6 @@ import type {
 import { JudgeFiles } from "server/logic/judgements/judge_files";
 import { JudgeRunner } from "server/logic/judgements/judge_runner";
 import { CheckerKind, Language, TaskType } from "common/types/constants";
-import { Transaction } from "kysely";
 import { Models } from "common/types";
 import { TaskConfigurationError, UnreachableError } from "common/errors";
 

--- a/src/server/logic/tasks/editor_utils.ts
+++ b/src/server/logic/tasks/editor_utils.ts
@@ -1,6 +1,6 @@
+import { Selectable } from "kysely";
 import { TaskDataTable } from "common/types";
 import { TaskDataBatchDTO, TaskDataCommunicationDTO, TaskDataOutputDTO } from "common/validation/task_validation";
-import { Selectable } from "kysely";
 
 type TaskDataDatabaseResponseKey =
   | 'id'

--- a/src/server/logic/tasks/update_editor_task.ts
+++ b/src/server/logic/tasks/update_editor_task.ts
@@ -433,6 +433,7 @@ export async function upsertTaskData(
       : await trx
           .insertInto("task_data")
           .values(
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars -- pre-existing error before eslint inclusion
             dataNew.map((data, index) => ({
               name: data.name,
               order: data.order,

--- a/src/server/logic/tasks/update_editor_task.ts
+++ b/src/server/logic/tasks/update_editor_task.ts
@@ -580,7 +580,7 @@ export async function updateEditorTask(task: TaskDTO): Promise<TaskDTO> {
       task.id,
       task.subtasks
     );
-    let dbSampleIO = await upsertTaskSampleIO(trx, task.id, task.sample_IO);
+    const dbSampleIO = await upsertTaskSampleIO(trx, task.id, task.sample_IO);
     const dbTaskData = await upsertTaskData(trx, subtasksWithData);
 
     const currentScriptIds = dbTaskScripts.map((script) => script.id);

--- a/src/types/nextjs.ts
+++ b/src/types/nextjs.ts
@@ -1,4 +1,5 @@
 
+// eslint-disable-next-line @typescript-eslint/ban-types -- pre-existing error before eslint inclusion
 export type NextContext<Params extends {}> = {
   params: Params;
 };


### PR DESCRIPTION
# Title

typescript-eslint was set to a verison that requires eslint 9.x, which has a ton of backwards incompatible changes. Next 14 uses eslint 8.x. So I downgraded typescript-eslint.

The only actual manual changes:

1. Downgrade typescript-eslint
2. Fix .eslintrc.js
3. Run `npm run lint:fix`
4. Install eslint-interactive 
5. Run `npx eslint-interactive src` to ignore all existing errors.

Steps 1-2 are in commit 1. Step 3 in commit 2. Step 4-5 in commit 3.