### PR TITLE
Use AOF+RDB persistence to avoid losing tasks

### DIFF
--- a/config/development/redis/redis.conf
+++ b/config/development/redis/redis.conf
@@ -1,0 +1,52 @@
+# Redis configuration file with RDB + AOF persistence
+
+# RDB persistence configuration
+# Save if at least 1 key changed in 15 minutes
+save 900 1
+# Save if at least 10 keys changed in 5 minutes
+save 300 10
+# Save if at least 10000 keys changed in 1 minute
+save 60 10000
+# Compress the RDB file
+rdbcompression yes
+# Use CRC64 checksum
+rdbchecksum yes
+# Filename for the RDB file
+dbfilename dump.rdb
+# Directory where to store the RDB file
+dir /data
+
+# AOF persistence configuration
+# Enable AOF
+appendonly yes
+# Filename for the AOF file
+appendfilename "appendonly.aof"
+# fsync every second (compromise between performance and safety)
+appendfsync everysec
+# fsync during rewrites
+no-appendfsync-on-rewrite no
+# Rewrite AOF if grows by 100%
+auto-aof-rewrite-percentage 100
+# Minimum size for AOF rewrite
+auto-aof-rewrite-min-size 64mb
+
+# AOF and RDB persistence
+# Use RDB preamble in AOF for faster rewrites
+aof-use-rdb-preamble yes
+
+# General Redis configuration
+protected-mode yes
+port 6379
+tcp-backlog 511
+timeout 0
+tcp-keepalive 300
+daemonize no
+supervised no
+pidfile /var/run/redis_6379.pid
+loglevel notice
+logfile ""
+databases 16
+always-show-logo yes
+set-proc-title yes
+proc-title-template "{title} {listen-addr} {server-mode}"
+stop-writes-on-bgsave-error yes

--- a/config/production/docker-compose.production.yml
+++ b/config/production/docker-compose.production.yml
@@ -50,10 +50,12 @@ services:
   hurado-redis:
     container_name: hurado-redis
     image: redis:7-alpine
+    command: redis-server /usr/local/etc/redis/redis.conf
     ports:
       - "6379"
     volumes:
       - ./volumes/redis:/data
+      - ./config/production/redis/redis.conf:/usr/local/etc/redis/redis.conf
   hurado-nginx:
     container_name: hurado-nginx
     image: nginx:1-alpine

--- a/config/production/redis/redis.conf
+++ b/config/production/redis/redis.conf
@@ -1,0 +1,52 @@
+# Redis configuration file with RDB + AOF persistence
+
+# RDB persistence configuration
+# Save if at least 1 key changed in 15 minutes
+save 900 1
+# Save if at least 10 keys changed in 5 minutes
+save 300 10
+# Save if at least 10000 keys changed in 1 minute
+save 60 10000
+# Compress the RDB file
+rdbcompression yes
+# Use CRC64 checksum
+rdbchecksum yes
+# Filename for the RDB file
+dbfilename dump.rdb
+# Directory where to store the RDB file
+dir /data
+
+# AOF persistence configuration
+# Enable AOF
+appendonly yes
+# Filename for the AOF file
+appendfilename "appendonly.aof"
+# fsync every second (compromise between performance and safety)
+appendfsync everysec
+# fsync during rewrites
+no-appendfsync-on-rewrite no
+# Rewrite AOF if grows by 100%
+auto-aof-rewrite-percentage 100
+# Minimum size for AOF rewrite
+auto-aof-rewrite-min-size 64mb
+
+# AOF and RDB persistence
+# Use RDB preamble in AOF for faster rewrites
+aof-use-rdb-preamble yes
+
+# General Redis configuration
+protected-mode yes
+port 6379
+tcp-backlog 511
+timeout 0
+tcp-keepalive 300
+daemonize no
+supervised no
+pidfile /var/run/redis_6379.pid
+loglevel notice
+logfile ""
+databases 16
+always-show-logo yes
+set-proc-title yes
+proc-title-template "{title} {listen-addr} {server-mode}"
+stop-writes-on-bgsave-error yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,10 +50,12 @@ services:
   hurado-redis:
     container_name: hurado-redis
     image: redis:7-alpine
+    command: redis-server /usr/local/etc/redis/redis.conf
     ports:
       - "6379"  # Blob service
     volumes:
       - ./volumes/redis:/data
+      - ./config/development/redis/redis.conf:/usr/local/etc/redis/redis.conf
   hurado-minio:
     container_name: hurado-minio
     image: minio/minio:latest


### PR DESCRIPTION
With RDB, you lose all writes since the last RDB persistence, in case of an ungraceful exit. RDB + AOF allows for not losing any data while allowing for fast resumption in case of ungraceful exits (since you only playback AOF lines since the last RDB snapshot)