### PR TITLE
Apply band-aid to center bugfix

### DIFF
--- a/src/common/latex/latex_render.tsx
+++ b/src/common/latex/latex_render.tsx
@@ -240,7 +240,7 @@ function LatexNodeEnvironmentX({ node, source }: LatexNodeProps<LatexNodeEnviron
       // (it would be arranged vertically by the flex-col)
       return (
         <div className="flex flex-col items-center text-center">
-          <div className="w-full">
+          <div>
             {renderEnvironmentContent(node, source)}
           </div>
         </div>
@@ -248,7 +248,7 @@ function LatexNodeEnvironmentX({ node, source }: LatexNodeProps<LatexNodeEnviron
     case "flushright":
       return (
         <div className="flex flex-col items-right text-right">
-          <div className="w-full">
+          <div>
             {renderEnvironmentContent(node, source)}
           </div>
         </div>
@@ -256,7 +256,7 @@ function LatexNodeEnvironmentX({ node, source }: LatexNodeProps<LatexNodeEnviron
     case "flushleft":
       return (
         <div className="flex flex-col items-left text-left">
-          <div className="w-full">
+          <div>
             {renderEnvironmentContent(node, source)}
           </div>
         </div>


### PR DESCRIPTION
The old code messed up and introduced this bug

![image](https://github.com/user-attachments/assets/d390765f-75b2-4448-a3ac-e8f45a01b22e)

For now, apply a temporary bug fix by removing the w-full from the inner div.  

![image](https://github.com/user-attachments/assets/4ff34197-f0c2-4ba8-892f-e8e4a1fe15ef)

The only issue is that this means nesting center/flushright/flushleft doesn't work together anymore, but... this is a band-aid fix, and the lesser of two evils