### PR TITLE
More proper fix to buggy center behavior

### DIFF
--- a/src/common/latex/latex_images.tsx
+++ b/src/common/latex/latex_images.tsx
@@ -51,7 +51,7 @@ export function LatexImageX({ node, source }: LatexNodeProps<LatexMacroImage>) {
   };
 
   // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text -- pre-existing error before eslint inclusion
-  return <img style={style} className="max-w-full" src={src} />;
+  return <img style={style} className="max-w-full inline-block" src={src} />;
 }
 
 

--- a/src/common/latex/latex_render.tsx
+++ b/src/common/latex/latex_render.tsx
@@ -240,25 +240,19 @@ function LatexNodeEnvironmentX({ node, source }: LatexNodeProps<LatexNodeEnviron
       // (it would be arranged vertically by the flex-col)
       return (
         <div className="flex flex-col items-center text-center">
-          <div className="w-full">
-            {renderEnvironmentContent(node, source)}
-          </div>
+          {renderEnvironmentContent(node, source)}
         </div>
       );
     case "flushright":
       return (
         <div className="flex flex-col items-right text-right">
-          <div className="w-full">
-            {renderEnvironmentContent(node, source)}
-          </div>
+          {renderEnvironmentContent(node, source)}
         </div>
       );
     case "flushleft":
       return (
         <div className="flex flex-col items-left text-left">
-          <div className="w-full">
-            {renderEnvironmentContent(node, source)}
-          </div>
+          {renderEnvironmentContent(node, source)}
         </div>
       );
     case "enumerate":

--- a/src/common/latex/latex_render.tsx
+++ b/src/common/latex/latex_render.tsx
@@ -240,19 +240,25 @@ function LatexNodeEnvironmentX({ node, source }: LatexNodeProps<LatexNodeEnviron
       // (it would be arranged vertically by the flex-col)
       return (
         <div className="flex flex-col items-center text-center">
-          {renderEnvironmentContent(node, source)}
+          <div className="max-w-full">
+            {renderEnvironmentContent(node, source)}
+          </div>
         </div>
       );
     case "flushright":
       return (
         <div className="flex flex-col items-right text-right">
-          {renderEnvironmentContent(node, source)}
+          <div className="max-w-full">
+            {renderEnvironmentContent(node, source)}
+          </div>
         </div>
       );
     case "flushleft":
       return (
         <div className="flex flex-col items-left text-left">
-          {renderEnvironmentContent(node, source)}
+          <div className="max-w-full">
+            {renderEnvironmentContent(node, source)}
+          </div>
         </div>
       );
     case "enumerate":

--- a/src/db/scripts/data/batch-demo.tex
+++ b/src/db/scripts/data/batch-demo.tex
@@ -82,3 +82,33 @@ Here is a nicer \href{http://example.com}{link}
 You can also nest all of these together. \href{http://example.com}{\HUGE{\sout{\tt{\bf\it{{link}}}}}}
 
 Here is a picture for your troubles \includegraphics{/tasks/batch-demo/attachments/path/to/chocolate-hills.jpg}
+
+Now let me test some stuff with center!
+
+\begin{center}
+    \includegraphics[scale=0.5]{/tasks/batch-demo/attachments/path/to/chocolate-hills.jpg}
+\end{center}
+
+
+\begin{center}
+    Some veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery looooooooooooooooooooooooooooooooooooooooong \textbf{text} here
+
+    \includegraphics[scale=0.5]{/tasks/batch-demo/attachments/path/to/chocolate-hills.jpg}
+
+
+    Some veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery looooooooooooooooooooooooooooooooooooooooong \textbf{text} here
+\end{center}
+
+\begin{center}
+    short \textbf{text} here
+
+    \includegraphics[scale=0.5]{/tasks/batch-demo/attachments/path/to/chocolate-hills.jpg}
+
+
+    short \textbf{text} here
+\end{center}
+
+
+\begin{center}
+    short \textbf{text} here
+\end{center}


### PR DESCRIPTION
By adding a wrapping div to the contents of a center, I fixed the bug where "I \textit{styled} this" would be rendered incorrectly.

However, that wrapping div now no longer inherits the centering from the flex-box.  it still gets the text-align, but specifically images look wrong now:

![image](https://github.com/user-attachments/assets/2ce6536f-96bc-403a-9349-25aa3b4d2c38)

I'll temporarily remove the inner div so that this doesnt look broken, and find the proper bugfix later.
