### PR TITLE
Fix score calcuation bug

### DIFF
--- a/src/server/logic/judgements/judge_runner.ts
+++ b/src/server/logic/judgements/judge_runner.ts
@@ -363,7 +363,9 @@ export async function upsertOverallVerdict(
     .where("task_subtasks.task_id", "=", task.id)
     .innerJoin("verdict_subtasks", "verdict_subtasks.subtask_id", "task_subtasks.id")
     .innerJoin("verdicts", "verdicts.id", "verdict_subtasks.verdict_id")
+    .innerJoin("submissions", "submissions.id", "verdicts.submission_id")
     .where("verdicts.is_official", "=", true)
+    .where("submissions.user_id", "=", user_id)
     .select(["task_subtasks.order", "verdict_subtasks.score_raw"])
     .execute();
 


### PR DESCRIPTION
There was an error in the overall score calculation in `judge_runner.ts`, where it would use the submissions of all users for a specific task.

I fixed the db query to filter by `user_id`.