### PR TITLE
Autodeploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get install -y pkg-config libcap-dev libsystemd-dev git make gcc
 
 # Checkout and get isolate
 RUN git clone https://github.com/ioi/isolate /isolate/
+RUN git checkout b5e87ec10c5c83830b0ab4b9d908437e4c14e426
 
 # Build isolate
 RUN make isolate

--- a/scripts/hrd.sh
+++ b/scripts/hrd.sh
@@ -84,14 +84,6 @@ function hrd_deploy() {
     # This does a full deploy to the staging or production server
     # This assumes that the .env file is already set up on the respective server
     # and no new dependencies are needed to be installed (i.e. no need to rebuild the docker image)
-    # If you need to do any of those, you'll want to do it manually by doing the following:
-    #
-    # git push origin main
-    # hrd connect production
-    # git pull --ff-only origin main
-    # ./tools/docker_build.sh
-    # vim .env
-    # hrd restart
     #
     # Pre-requisites for this command:
     # You need to add something like the following to your ~/.ssh/config file:
@@ -144,6 +136,7 @@ function hrd_deploy_server() {
     # Server-side script for deploying the latest changes to the production server
     set -e
     cd ~/hurado/
+    ./scripts/docker_build.sh
     ./scripts/next_build.sh
     $HRD_CMD compose restart
     $HRD_CMD shell npm run db:migrate

--- a/scripts/local/npm_ci.sh
+++ b/scripts/local/npm_ci.sh
@@ -8,4 +8,5 @@ docker run \
     -v "$PROJECT_ROOT:/app" \
     -w /app \
     --user $(id -u):$(id -g) \
+    -e NPM_CONFIG_CACHE=/app/.npm \
     noiph/hurado:latest npm ci

--- a/scripts/setup_hooks.sh
+++ b/scripts/setup_hooks.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+if [ -z "$1" ]; then
+    echo "Error: Missing bare repository directory parameter."
+    echo "Usage: $0 <path_to_bare_repo>"
+    exit 1
+fi
+
+BARE_REPO_DIR="$1"
+WORK_TREE=$(pwd)
+
+if [ -d "$BARE_REPO_DIR" ]; then
+    read -p "Directory '$BARE_REPO_DIR' already exists. Delete it? (y/N): " confirm
+
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+        rm -rf "$BARE_REPO_DIR"
+        echo "Deleted '$BARE_REPO_DIR'."
+    else
+        echo "Setup aborted. Existing directory was kept."
+        exit 1
+    fi
+fi
+
+git init --bare "$BARE_REPO_DIR"
+
+HOOK_FILE="$BARE_REPO_DIR/hooks/post-receive"
+cat > "$HOOK_FILE" <<EOL
+#!/bin/bash
+set -e
+
+#https://stackoverflow.com/questions/32910661/pretend-to-be-a-tty-in-bash-for-any-command
+faketty () {
+    script -qefc "\$(printf "%q " "\$@")" /dev/null
+}
+
+while read oldrev newrev refname; do
+    if [[ "\$refname" == refs/heads/* ]]; then
+        BRANCH="\${refname#refs/heads/}"
+        PWD=\$(pwd)
+        unset GIT_DIR
+
+        # this assumes the work tree already exists
+        set +e
+        cd $WORK_TREE
+        faketty ./scripts/hrd.sh compose stop
+        set -e
+
+        cd \$PWD
+        GIT_WORK_TREE="$WORK_TREE" git checkout -f "\$BRANCH"
+
+        cd $WORK_TREE
+        faketty ./scripts/hrd.sh deploy_server | cat
+    fi
+done
+EOL
+
+chmod +x $HOOK_FILE


### PR DESCRIPTION
# Title

Brief description of the pull request (PR).

## Proposed changes

- Current approach uses a bare git repository that accepts pushes, and then checks out the files to ~/hurado
- The bare git repository can be initialized by calling `./scripts/setup_hooks.sh <path to bare git repo>`
- Right now, hurado's scripts assume that it is in a git repository, which might not be the case here (there is no need to keep ~/hurado as a git repo as the bare git repository is the one used)
- Also the post-receive hook script isn't auto-updated