### PR TITLE
Add search bar for tasks

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,48 @@
+import { sql } from "kysely";
+import { db } from "db";
+import { DefaultLayout } from "client/components/layouts/default_layout";
+import { TaskScoredSummaryDTO } from "common/types";
+import { getSession } from "server/sessions";
+import { TaskCard } from "client/components/cards/common_card";
+
+async function getSearchResults(queryString: string, userId: string | null): Promise<TaskScoredSummaryDTO[]> {
+  const tasks = db.transaction().execute(async (trx) => {
+    const tasks = await trx
+      .selectFrom("tasks")
+      .leftJoin("overall_verdicts", (join) =>
+        join.onRef("overall_verdicts.task_id", "=", "tasks.id")
+          .on("overall_verdicts.user_id", "=", userId)
+      ).select([
+        "tasks.id",
+        "tasks.slug",
+        "tasks.title",
+        "tasks.description",
+        "overall_verdicts.score_overall",
+        "overall_verdicts.score_max"
+      ]).execute();
+
+    return tasks;
+  });
+
+  return tasks
+}
+
+export async function SearchResultsPage({ searchParams }: { searchParams: Promise<{ query: string }> }) {
+  const session = await getSession();
+  const userId = session?.user?.id ?? null;
+
+  const params = await searchParams;
+  const queryString = params.query;
+
+  const results = await getSearchResults(queryString, userId);
+  return (
+    <DefaultLayout>
+      <p> {results.length} results found </p>
+      {results.map((task) => (
+        <TaskCard key={task.slug} task={task} />
+      ))}
+    </DefaultLayout>
+  );
+}
+
+export default SearchResultsPage;

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -4,11 +4,10 @@ import { DefaultLayout } from "client/components/layouts/default_layout";
 import { TaskScoredSummaryDTO } from "common/types";
 import { getSession } from "server/sessions";
 import { TaskCard } from "client/components/cards/common_card";
+import { ProblemSearchBar } from "client/components/problem_search_bar/problem_search_bar";
 
 async function getSearchResults(queryString: string, userId: string | null): Promise<TaskScoredSummaryDTO[]> {
-  const tasks = db.transaction().execute(async (trx) => {
-    const tasks = await trx
-      .selectFrom("tasks")
+  const tasks = db.selectFrom("tasks")
       .leftJoin("overall_verdicts", (join) =>
         join.onRef("overall_verdicts.task_id", "=", "tasks.id")
           .on("overall_verdicts.user_id", "=", userId)
@@ -19,12 +18,10 @@ async function getSearchResults(queryString: string, userId: string | null): Pro
         "tasks.description",
         "overall_verdicts.score_overall",
         "overall_verdicts.score_max"
-      ]).execute();
+      ])
+      .where('tasks.title', 'ilike', sql<string>`CONCAT('%', ${queryString}::text, '%')`).execute();
 
-    return tasks;
-  });
-
-  return tasks
+  return tasks;
 }
 
 export async function SearchResultsPage({ searchParams }: { searchParams: Promise<{ query: string }> }) {
@@ -34,13 +31,19 @@ export async function SearchResultsPage({ searchParams }: { searchParams: Promis
   const params = await searchParams;
   const queryString = params.query;
 
+
   const results = await getSearchResults(queryString, userId);
   return (
     <DefaultLayout>
-      <p> {results.length} results found </p>
-      {results.map((task) => (
-        <TaskCard key={task.slug} task={task} />
-      ))}
+      <ProblemSearchBar />
+      <div className="mt-2 mb-4">
+        {results.length} result(s) found for task named &quot; {queryString} &quot;
+      </div>
+      <div className="flex flex-col items-center gap-4 mt-8">
+        {results.map((task) => (
+          <TaskCard key={task.slug} task={task} />
+        ))}
+      </div>
     </DefaultLayout>
   );
 }

--- a/src/app/sets/page.tsx
+++ b/src/app/sets/page.tsx
@@ -3,6 +3,7 @@ import { db } from "db";
 import { DefaultLayout } from "client/components/layouts/default_layout";
 import { ProblemSetSummaryDTO } from "common/types/problem_sets";
 import { ProblemSetCard } from "client/components/cards";
+import { ProblemSearchBar } from "client/components/problem_search_bar/problem_search_bar";
 import { EmptyNoticePage } from "client/components/empty_notice";
 
 async function getProblemSetsData(): Promise<ProblemSetSummaryDTO[]> {
@@ -33,6 +34,7 @@ export async function ProblemSetListPage() {
 
   return (
     <DefaultLayout>
+      <ProblemSearchBar />
       <div className="flex flex-col items-center gap-4">
         {sets.map((set) => (
           <ProblemSetCard key={set.slug} set={set} />

--- a/src/client/components/problem_search_bar/problem_search_bar.tsx
+++ b/src/client/components/problem_search_bar/problem_search_bar.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { getPath, Path } from "client/paths";
+
+export const ProblemSearchBar = () => {
+  const router = useRouter();
+
+  const submit = (formData: FormData) => {
+    const query = formData.get("query");
+    if (query !== null && query !== '') {
+      router.push(getPath({ kind: Path.TaskSearch, query: query.toString() }));
+    }
+  };
+
+  return (
+    <div className="py-2">
+      <form action={submit}>
+        <input type="text"
+          name="query"
+          className="p-1 m-2 border border-gray-300 text-gray-500 rounded-md"
+          placeholder="Search by task name..." />
+        <button className="p-1 text-white bg-blue-400 focus:bg-purple-500 rounded-md" type="submit"> Search </button>
+      </form>
+    </div>
+  );
+};

--- a/src/client/paths.ts
+++ b/src/client/paths.ts
@@ -9,6 +9,7 @@ export enum Path {
   AccountForgotPassword = "AccountForgotPassword",
   AccountPasswordReset = "AccountPasswordReset",
   Submission = "Submission",
+  TaskSearch = "TaskSearch",
   TaskList = "TaskList",
   TaskView = "TaskView",
   TaskEdit = "TaskEdit",
@@ -37,6 +38,7 @@ export type PathArguments =
   | { kind: Path.AccountForgotPassword }
   | { kind: Path.AccountPasswordReset; token: string }
   | { kind: Path.Submission; uuid: string }
+  | { kind: Path.TaskSearch; query: string }
   | { kind: Path.TaskList }
   | { kind: Path.TaskView; slug: string }
   | { kind: Path.TaskEdit; uuid: string }
@@ -72,6 +74,8 @@ export function getPath(args: PathArguments) {
       return `/password-reset?token=${args.token}`;
     case Path.Submission:
       return `/submissions/${uuidToHuradoID(args.uuid)}`;
+    case Path.TaskSearch:
+      return addSearchParameters("/search", { query: args.query });
     case Path.TaskList:
       return "/tasks";
     case Path.TaskView:


### PR DESCRIPTION
# Title

Lets the user search tasks by name. 

## Proposed changes

- Adds a `/search?query=` endpoint to the app
- Adds a search bar to `/sets`
